### PR TITLE
fix: remove hardcoded disableBlockStreaming to allow config control

### DIFF
--- a/src/agent/handler.ts
+++ b/src/agent/handler.ts
@@ -560,9 +560,6 @@ async function processAgentMessage(params: {
                 error?.(`[wecom-agent] ${info.kind} reply error: ${String(err)}`);
             },
         },
-        replyOptions: {
-            disableBlockStreaming: true,
-        },
     });
 }
 


### PR DESCRIPTION
# 现状

- Agent模式 + verbose off + blockStreamingDefault=false 的情况下，不会显示工具调用的消息(verbose off)，工具调用的文本消息和最后总结的文本消息，是最后才一起出现的。
- Agent模式 + verbose **on** + blockStreamingDefault=**true** 的情况下，工具调用的消息会在前面出现(verbose on)，而且是逐条出现，有类似流式的效果(blockStreamingDefault true)。而工具调用的文本消息和最后总结的文本消息，**还是最后才一起出现的**。

当前聊天效果
```
Momojie 2/25 17:00:07
调用两次工具，并都附带文本消息试试

OpenClaw-Echo-Agent 2/25 17:00:15
📖 Read: from ~/.openclaw/workspace/USER.md

OpenClaw-Echo-Agent 2/25 17:00:26
📖 Read: from ~/.openclaw/workspace/IDENTITY.md

OpenClaw-Echo-Agent 2/25 17:00:37
好的，测试一下。这是第一段测试文本。

OpenClaw-Echo-Agent 2/25 17:00:37
这是第二段测试文本。

OpenClaw-Echo-Agent 2/25 17:00:38
两个文件都读取完成了。企业微信上消息显示情况怎么样？是分块还是合并？
```

# 目标

Agent模式 + verbose **on** + blockStreamingDefault=**true** 的情况下，工具调用的文本消息在工具调用的消息前出现，最后再出现总结的文本消息。

修复后的聊天效果
```
Momojie 2/25 17:04:51
重启完了，调用两次工具，并都附带文本消息试试

OpenClaw-Echo-Agent 2/25 17:04:58
好的，测试一下。这是第一段测试文本。

OpenClaw-Echo-Agent 2/25 17:04:58
📖 Read: from ~/.openclaw/workspace/USER.md

OpenClaw-Echo-Agent 2/25 17:05:06
这是第二段测试文本。

OpenClaw-Echo-Agent 2/25 17:05:06
📖 Read: from ~/.openclaw/workspace/IDENTITY.md

OpenClaw-Echo-Agent 2/25 17:05:10
两个文件都读取完成了。企业微信上消息显示情况怎么样？分块和顺序都正确吗？
```

# 原因

代码中硬编码了 `disableBlockStreaming: true` 未知原因。

# 修复方案

去除硬编码的配置