### PR TITLE
refactor: 使用 registerHttpRoute 替换 registerHttpHandler

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -15,16 +15,21 @@ const plugin = {
   configSchema: emptyPluginConfigSchema(),
   /**
    * **register (注册插件)**
-   * 
+   *
    * OpenClaw 插件入口点。
    * 1. 注入 Runtime 环境 (api.runtime)。
    * 2. 注册 WeCom 渠道插件 (ChannelPlugin)。
-   * 3. 注册 Webhook HTTP 处理器 (handleWecomWebhookRequest)。
+   * 3. 注册 Webhook HTTP 路由 (/plugins/wecom/*)。
    */
   register(api: OpenClawPluginApi) {
     setWecomRuntime(api.runtime);
     api.registerChannel({ plugin: wecomPlugin });
-    api.registerHttpHandler(handleWecomWebhookRequest);
+    api.registerHttpRoute({
+      path: "/plugins/wecom",
+      handler: handleWecomWebhookRequest,
+      auth: "plugin",
+      match: "prefix",
+    });
   },
 };
 


### PR DESCRIPTION
## Summary
- 将插件注册方式从 `api.registerHttpHandler` 迁移到新的 `api.registerHttpRoute` API
- 指定路由路径前缀 `/plugins/wecom`，认证模式为 `plugin`，匹配方式为 `prefix`

## Test plan
- [x] 验证 Bot 模式 webhook `/plugins/wecom/bot` 正常接收消息
- [x] 验证 Agent 模式 webhook `/plugins/wecom/agent` 正常接收回调
- [x] 验证旧路径 `/plugins/wecom` 兼容性