### PR TITLE
fix: 恢复 preferUserForDigits

### DIFF
--- a/src/target.ts
+++ b/src/target.ts
@@ -39,14 +39,14 @@ export interface ScopedWecomTarget {
  *    - 纯数字 -> 默认 User ID (用户)，避免误判部门导致 81013 错误
  *    - 其他 -> User ID (用户)
  * 
- * @param raw - The raw target string (e.g. "party:1", "zhangsan", "wecom:user:0404777")
+ * @param raw - The raw target string (e.g. "party:1", "zhangsan", "wecom:user:xxx")
  */
 export function resolveWecomTarget(raw: string | undefined, options?: { preferUserForDigits?: boolean }): WecomTarget | undefined {
     if (!raw?.trim()) return undefined;
 
     const trimmed = raw.trim();
 
-    // 1. 先检查原始字符串中的类型前缀（处理 user:0404777 无前缀格式）
+    // 1. 先检查原始字符串中的类型前缀（处理 user:xxx 无前缀格式）
     // 这样即使没有 wecom: 前缀，也能正确识别类型
     if (/^user:/i.test(trimmed)) {
         return { touser: trimmed.replace(/^user:/i, "").trim() };
@@ -64,7 +64,7 @@ export function resolveWecomTarget(raw: string | undefined, options?: { preferUs
     // 2. Remove standard namespace prefixes (移除标准命名空间前缀)
     let clean = trimmed.replace(/^(wecom-agent|wecom|wechatwork|wework|qywx):/i, "");
 
-    // 3. 再次检查类型前缀（处理 wecom:user:0404777 格式）
+    // 3. 再次检查类型前缀（处理 wecom:user:xxx 格式）
     if (/^user:/i.test(clean)) {
         return { touser: clean.replace(/^user:/i, "").trim() };
     }


### PR DESCRIPTION
fix: 恢复 preferUserForDigits
现象：创建定时任务发送给企业微信用户时，出现 81013 user & party & tag all invalid 错误。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option for numeric target interpretation, allowing digits to map to User IDs instead of defaulting to Department IDs.

* **Documentation**
  * Updated inline examples with standardized target identifiers.
  * Enhanced comments documenting numeric target handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->