### PR TITLE
wecom markdown message format [企业微信markdown格式问题解决]

### DIFF
--- a/src/outbound.ts
+++ b/src/outbound.ts
@@ -1,5 +1,6 @@
 import type { ChannelOutboundAdapter, ChannelOutboundContext } from "openclaw/plugin-sdk";
 import { WecomAgentDeliveryService } from "./capability/agent/index.js";
+import { toWeComMarkdownV2 } from "./wecom_msg_adapter/markdown_adapter.js";
 import {
   resolveWecomMergedMediaLocalRoots,
   resolveWecomMediaMaxBytes,
@@ -135,10 +136,11 @@ async function sendTextViaBotWs(params: {
       `WeCom outbound account=${accountId} is configured for Bot WS active push, but the WS transport is not connected.`,
     );
   }
+  const markdownText = toWeComMarkdownV2(params.text);
   console.log(
-    `[wecom-outbound] Sending Bot WS active message to target=${String(params.to ?? "")} chatId=${chatId} (len=${params.text.length})`,
+    `[wecom-outbound] Sending Bot WS active message to target=${String(params.to ?? "")} chatId=${chatId} (len=${markdownText.length})`,
   );
-  await handle.sendMarkdown(chatId, params.text);
+  await handle.sendMarkdown(chatId, markdownText);
   console.log(`[wecom-outbound] Successfully sent Bot WS active message to ${chatId}`);
   return true;
 }

--- a/src/transport/bot-ws/reply.ts
+++ b/src/transport/bot-ws/reply.ts
@@ -9,6 +9,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk";
 import { resolveWecomMediaMaxBytes, resolveWecomMergedMediaLocalRoots } from "../../config/index.js";
 import { getWecomRuntime } from "../../runtime.js";
 import type { ReplyHandle, ReplyPayload } from "../../types/index.js";
+import { toWeComMarkdownV2 } from "../../wecom_msg_adapter/markdown_adapter.js";
 import { uploadAndSendBotWsMedia } from "./media.js";
 
 const PLACEHOLDER_KEEPALIVE_MS = 3000;
@@ -307,13 +308,13 @@ export function createBotWsReplyHandle(params: {
           // Send push message for other events
           await params.client.sendMessage(peerId, {
             msgtype: "markdown",
-            markdown: { content: finalText },
+            markdown: { content: toWeComMarkdownV2(finalText) },
           });
         } else {
           await params.client.replyStream(
             params.frame,
             resolveStreamId(),
-            finalText,
+            toWeComMarkdownV2(finalText),
             info.kind === "final",
           );
         }

--- a/src/wecom_msg_adapter/markdown_adapter.ts
+++ b/src/wecom_msg_adapter/markdown_adapter.ts
@@ -227,6 +227,7 @@ function normalizeTables(text: string): string {
   }
 
   // Pass 2: detect and normalize table blocks.
+  // Surround each block with blank lines so WeCom recognises them as block elements.
   const out: string[] = [];
   let i = 0;
 
@@ -240,7 +241,18 @@ function normalizeTables(text: string): string {
         j += 1;
       }
 
+      // Ensure a blank line before the table
+      if (out.length > 0 && out[out.length - 1]?.trim() !== "") {
+        out.push("");
+      }
+
       out.push(...normalizeTableBlock(tableBlock));
+
+      // Ensure a blank line after the table
+      if (j < stitched.length && stitched[j]?.trim() !== "") {
+        out.push("");
+      }
+
       i = j;
     } else {
       out.push(stitched[i]!);
@@ -259,30 +271,38 @@ function looksLikeTableRow(line: string): boolean {
   return (stripped.match(/\|/g) || []).length >= 2;
 }
 
+function isTableSeparatorRow(row: string): boolean {
+  // A separator row only contains |, -, :, and spaces.
+  const inner = row.replace(/^\|/, "").replace(/\|$/, "");
+  return inner.split("|").every(c => /^[\s\-:]+$/.test(c) && c.includes("-"));
+}
+
+function normalizeOneTableRow(line: string): string {
+  const raw = String(line).trim();
+  if (!raw) return raw;
+
+  // Split by | then strip leading/trailing empty tokens from surrounding |
+  const parts = raw.split("|");
+  const inner = raw.startsWith("|") ? parts.slice(1) : parts;
+  const cells = (raw.endsWith("|") ? inner.slice(0, -1) : inner).map(p => p.trim());
+
+  // Always emit in canonical form: | cell | cell | ...
+  return "| " + cells.join(" | ") + " |";
+}
+
 function normalizeTableBlock(lines: string[]): string[] {
-  return lines.map(line => {
-    const raw = String(line).trim();
-    if (!raw) return line;
+  const rows = lines.map(normalizeOneTableRow).filter(r => r.length > 0);
+  if (rows.length === 0) return [];
 
-    let parts = raw.split("|").map(p => p.trim());
-    let left = "";
-    let right = "";
+  // If there is no separator row as the second row, inject a plain one.
+  // markdown_v2 requires a separator row; without it the table won't render.
+  if (rows.length < 2 || !isTableSeparatorRow(rows[1]!)) {
+    const colCount = Math.max(1, (rows[0]!.match(/\|/g) ?? []).length - 1);
+    const sep = "| " + Array(colCount).fill("---").join(" | ") + " |";
+    return [rows[0]!, sep, ...rows.slice(1)];
+  }
 
-    if (raw.startsWith("|")) {
-      left = "| ";
-      parts = parts.slice(1);
-    }
-
-    if (raw.endsWith("|")) {
-      parts = parts.slice(0, -1);
-      right = " |";
-    }
-
-    // Normalise alignment markers in separator rows (:---:, :---, ---:) → ---
-    parts = parts.map(p => (/^:?-+:?$/.test(p) ? "---" : p));
-
-    return left + parts.join(" | ") + right;
-  });
+  return rows;
 }
 
 function cleanupWhitespace(text: string): string {

--- a/src/wecom_msg_adapter/markdown_adapter.ts
+++ b/src/wecom_msg_adapter/markdown_adapter.ts
@@ -237,8 +237,7 @@ function normalizeTables(text: string): string {
     stitched.push(line);
   }
 
-  // Pass 2: detect and normalize table blocks.
-  // Surround each block with blank lines so WeCom recognises them as block elements.
+  // Pass 2: convert each table block to plain text lines.
   const out: string[] = [];
   let i = 0;
 
@@ -252,14 +251,12 @@ function normalizeTables(text: string): string {
         j += 1;
       }
 
-      // Ensure a blank line before the table
       if (out.length > 0 && out[out.length - 1]?.trim() !== "") {
         out.push("");
       }
 
-      out.push(...normalizeTableBlock(tableBlock));
+      out.push(...tableToPlainText(tableBlock));
 
-      // Ensure a blank line after the table
       if (j < stitched.length && stitched[j]?.trim() !== "") {
         out.push("");
       }
@@ -276,44 +273,33 @@ function normalizeTables(text: string): string {
 
 function looksLikeTableRow(line: string): boolean {
   const stripped = String(line).trim();
-  // Must start with | — this rules out continuation fragments and avoids
-  // false positives on lines that merely contain a pipe character.
   if (!stripped.startsWith("|")) return false;
   return (stripped.match(/\|/g) || []).length >= 2;
 }
 
 function isTableSeparatorRow(row: string): boolean {
-  // A separator row only contains |, -, :, and spaces.
   const inner = row.replace(/^\|/, "").replace(/\|$/, "");
   return inner.split("|").every(c => /^[\s\-:]+$/.test(c) && c.includes("-"));
 }
 
-function normalizeOneTableRow(line: string): string {
-  const raw = String(line).trim();
-  if (!raw) return raw;
-
-  // Split by | then strip leading/trailing empty tokens from surrounding |
+function extractTableCells(line: string): string[] {
+  const raw = line.trim();
   const parts = raw.split("|");
   const inner = raw.startsWith("|") ? parts.slice(1) : parts;
   const cells = (raw.endsWith("|") ? inner.slice(0, -1) : inner).map(p => p.trim());
-
-  // Always emit in canonical form: | cell | cell | ...
-  return "| " + cells.join(" | ") + " |";
+  return cells.filter(c => c.length > 0);
 }
 
-function normalizeTableBlock(lines: string[]): string[] {
-  const rows = lines.map(normalizeOneTableRow).filter(r => r.length > 0);
-  if (rows.length === 0) return [];
-
-  // If there is no separator row as the second row, inject a plain one.
-  // markdown_v2 requires a separator row; without it the table won't render.
-  if (rows.length < 2 || !isTableSeparatorRow(rows[1]!)) {
-    const colCount = Math.max(1, (rows[0]!.match(/\|/g) ?? []).length - 1);
-    const sep = "| " + Array(colCount).fill("---").join(" | ") + " |";
-    return [rows[0]!, sep, ...rows.slice(1)];
+function tableToPlainText(lines: string[]): string[] {
+  const result: string[] = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    if (isTableSeparatorRow(line.trim())) continue;
+    const cells = extractTableCells(line);
+    if (cells.length === 0) continue;
+    result.push(cells.join(" | "));
   }
-
-  return rows;
+  return result;
 }
 
 function cleanupWhitespace(text: string): string {

--- a/src/wecom_msg_adapter/markdown_adapter.ts
+++ b/src/wecom_msg_adapter/markdown_adapter.ts
@@ -1,0 +1,287 @@
+/**
+ * 将较完整的 Markdown 降级转换为更适合企业微信 markdown_v2 的子集。
+ *
+ * 保守策略：
+ * - 保留：标题、粗体、斜体、引用、链接、行内代码、普通列表、表格
+ * - 降级：代码块、图片、任务列表、分隔线、HTML、脚注、复杂语法
+ * - 清理：多余空行、非法控制字符、过深嵌套
+ */
+export function toWeComMarkdownV2(markdown: unknown, maxLength = 4096): string {
+  if (!markdown) return "";
+
+  let text = String(markdown).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+
+  const extracted = extractInlineCodeSpans(text);
+  text = extracted.text;
+  const inlineCodeStore = extracted.store;
+
+  text = convertFencedCodeBlocks(text);
+  text = convertIndentedCodeBlocks(text);
+  text = convertImages(text);
+  text = convertTaskLists(text);
+  text = convertThematicBreaks(text);
+  text = stripHtml(text);
+  text = removeFootnotes(text);
+  text = removeUnfriendlyExtensions(text);
+  text = flattenDeepNesting(text);
+  text = normalizeTables(text);
+  text = restoreInlineCodeSpans(text, inlineCodeStore);
+  text = cleanupWhitespace(text);
+
+  if (maxLength != null && text.length > maxLength) {
+    text = truncateSafely(text, maxLength);
+  }
+
+  return text;
+}
+
+const INLINE_CODE_PREFIX = "\uFFF0INLINECODE";
+const INLINE_CODE_SUFFIX = "\uFFF1";
+
+function extractInlineCodeSpans(text: string): { text: string; store: string[] } {
+  const store: string[] = [];
+  const replaced = text.replace(/`([^`\n]+?)`/g, (_, content: string) => {
+    const idx = store.length;
+    store.push(content);
+    return `${INLINE_CODE_PREFIX}${idx}${INLINE_CODE_SUFFIX}`;
+  });
+  return { text: replaced, store };
+}
+
+function restoreInlineCodeSpans(text: string, store: string[]): string {
+  const re = new RegExp(`${INLINE_CODE_PREFIX}(\\d+)${INLINE_CODE_SUFFIX}`, "g");
+  return text.replace(re, (_, idxStr: string) => {
+    const idx = Number(idxStr);
+    const content = idx >= 0 && idx < store.length ? store[idx] : "";
+    return `\`${content}\``;
+  });
+}
+
+function convertFencedCodeBlocks(text: string): string {
+  return text.replace(/```([a-zA-Z0-9_+\-]*)\n([\s\S]*?)```/g, (_, lang: string, code: string) => {
+    const safeLang = (lang || "").trim();
+    const safeCode = String(code || "").replace(/^\n+|\n+$/g, "");
+    if (!safeCode.trim()) return "";
+
+    const title = safeLang ? `代码（${safeLang}）：` : "代码：";
+    return `\n${title}\n${safeCode}\n`;
+  });
+}
+
+function convertIndentedCodeBlocks(text: string): string {
+  const lines = text.split("\n");
+  const out: string[] = [];
+  let buffer: string[] = [];
+
+  const flushBuffer = () => {
+    if (!buffer.length) return;
+    const block = buffer
+      .map(line => (line.startsWith("    ") ? line.slice(4) : line))
+      .join("\n")
+      .replace(/\s+$/g, "");
+
+    if (block) {
+      out.push("代码：");
+      out.push(...block.split("\n"));
+    }
+    buffer = [];
+  };
+
+  for (const line of lines) {
+    if (/^    \S/.test(line)) {
+      buffer.push(line);
+    } else {
+      flushBuffer();
+      out.push(line);
+    }
+  }
+
+  flushBuffer();
+  return out.join("\n");
+}
+
+function convertImages(text: string): string {
+  text = text.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_, alt: string, url: string) => {
+    const safeAlt = (alt || "").trim() || "图片";
+    const safeUrl = (url || "").trim();
+    return `[图片：${safeAlt}](${safeUrl})`;
+  });
+
+  text = text.replace(/!\[([^\]]*)\]\[[^\]]*\]/g, (_, alt: string) => {
+    const safeAlt = (alt || "").trim() || "图片";
+    return `图片：${safeAlt}`;
+  });
+
+  return text;
+}
+
+function convertTaskLists(text: string): string {
+  text = text.replace(/^(\s*[-*+]\s+)\[x\]\s+/gim, "✅ ");
+  text = text.replace(/^(\s*[-*+]\s+)\[\s\]\s+/gm, "⬜ ");
+  return text;
+}
+
+function convertThematicBreaks(text: string): string {
+  return text.replace(/^\s*([-*_])(\s*\1){2,}\s*$/gm, "────────");
+}
+
+function stripHtml(text: string): string {
+  text = text.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
+  text = text.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "");
+
+  text = text.replace(/<br\s*\/?>/gi, "\n");
+  text = text.replace(/<\/p\s*>/gi, "\n");
+  text = text.replace(/<p\b[^>]*>/gi, "");
+
+  const simpleTags = [
+    "div", "span", "b", "strong", "i", "em", "u",
+    "font", "small", "big", "section", "article",
+    "header", "footer", "main",
+  ];
+
+  for (const tag of simpleTags) {
+    const re = new RegExp(`</?${tag}\\b[^>]*>`, "gi");
+    text = text.replace(re, "");
+  }
+
+  text = text.replace(/<[^>]+>/g, "");
+  text = decodeHtmlEntities(text);
+
+  return text;
+}
+
+function decodeHtmlEntities(text: string): string {
+  const map: Record<string, string> = {
+    "&amp;": "&",
+    "&lt;": "<",
+    "&gt;": ">",
+    "&quot;": "\"",
+    "&#39;": "'",
+    "&nbsp;": " ",
+  };
+
+  return text.replace(/&amp;|&lt;|&gt;|&quot;|&#39;|&nbsp;/g, m => map[m] ?? m);
+}
+
+function removeFootnotes(text: string): string {
+  text = text.replace(/^\[\^[^\]]+\]:\s+.*(?:\n(?: {2,}|\t).*)*/gm, "");
+  text = text.replace(/\[\^[^\]]+\]/g, "[注]");
+  return text;
+}
+
+function removeUnfriendlyExtensions(text: string): string {
+  text = text.replace(/~~(.*?)~~/g, "$1");
+  text = text.replace(/==(.*?)==/g, "$1");
+  text = text.replace(/(?<!~)~([^~\n]+)~(?!~)/g, "$1");
+  text = text.replace(/\^([^^\n]+)\^/g, "$1");
+
+  text = text.replace(
+    /```(?:mermaid|math|latex|tex|graphviz|plantuml)\n([\s\S]*?)```/gi,
+    "\n内容略（不支持的扩展块）\n",
+  );
+
+  return text;
+}
+
+function flattenDeepNesting(text: string): string {
+  const lines = text.split("\n");
+  const out: string[] = [];
+
+  for (let line of lines) {
+    if (/^\s{4,}[-*+]\s+/.test(line)) {
+      line = line.replace(/^\s+/, "  ");
+    }
+
+    if (/^\s*(>\s*){2,}/.test(line)) {
+      const content = line.replace(/^\s*(>\s*)+/, "");
+      line = `> ${content}`;
+    }
+
+    out.push(line);
+  }
+
+  return out.join("\n");
+}
+
+function normalizeTables(text: string): string {
+  const lines = text.split("\n");
+  const out: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    if (looksLikeTableRow(lines[i]!)) {
+      const tableBlock = [lines[i]!];
+      let j = i + 1;
+
+      while (j < lines.length && looksLikeTableRow(lines[j]!)) {
+        tableBlock.push(lines[j]!);
+        j += 1;
+      }
+
+      out.push(...normalizeTableBlock(tableBlock));
+      i = j;
+    } else {
+      out.push(lines[i]!);
+      i += 1;
+    }
+  }
+
+  return out.join("\n");
+}
+
+function looksLikeTableRow(line: string): boolean {
+  const stripped = String(line).trim();
+  if (!stripped.includes("|")) return false;
+  return (stripped.match(/\|/g) || []).length >= 2;
+}
+
+function normalizeTableBlock(lines: string[]): string[] {
+  return lines.map(line => {
+    const raw = String(line).trim();
+    if (!raw) return line;
+
+    let parts = raw.split("|").map(p => p.trim());
+    let left = "";
+    let right = "";
+
+    if (raw.startsWith("|")) {
+      left = "| ";
+      parts = parts.slice(1);
+    }
+
+    if (raw.endsWith("|")) {
+      parts = parts.slice(0, -1);
+      right = " |";
+    }
+
+    return left + parts.join(" | ") + right;
+  });
+}
+
+function cleanupWhitespace(text: string): string {
+  const lines = text.split("\n").map(line => {
+    let s = line.replace(/[ \t]+$/g, "");
+    s = s.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, "");
+    return s;
+  });
+
+  text = lines.join("\n");
+  text = text.replace(/\n{3,}/g, "\n\n");
+  return text.trim();
+}
+
+function truncateSafely(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+
+  const suffix = "\n\n（内容过长，已截断）";
+  const allowed = maxLength - suffix.length;
+  if (allowed <= 0) return text.slice(0, maxLength);
+
+  let truncated = text.slice(0, allowed);
+  const cut = truncated.lastIndexOf("\n");
+  if (cut > maxLength * 0.7) {
+    truncated = truncated.slice(0, cut);
+  }
+
+  return truncated.replace(/\s+$/g, "") + suffix;
+}

--- a/src/wecom_msg_adapter/markdown_adapter.ts
+++ b/src/wecom_msg_adapter/markdown_adapter.ts
@@ -205,25 +205,36 @@ function flattenDeepNesting(text: string): string {
 
 function normalizeTables(text: string): string {
   // Pass 1: stitch broken table rows back together.
-  // Models sometimes split a single row across two lines: the first starts
-  // with | but does not end with |, and the second is a continuation that
-  // doesn't start with |.  Re-join them before block detection.
+  // Models may split a single row across multiple lines in several ways:
+  //   a) first part ends without |, continuation does NOT start with |
+  //   b) first part ends without |, blank line(s), continuation starts with |
+  //   c) first part ends without |, blank line(s), lone | on its own line
+  // We absorb any blank lines that follow an incomplete row and keep merging
+  // until the accumulated row ends with |.
   const rawLines = text.split("\n");
   const stitched: string[] = [];
 
-  for (const line of rawLines) {
+  for (let idx = 0; idx < rawLines.length; idx++) {
+    const line = rawLines[idx]!;
+    const trimmed = line.trim();
     const prev = stitched[stitched.length - 1];
-    if (
-      prev !== undefined &&
-      prev.trim().startsWith("|") &&
-      !prev.trim().endsWith("|") &&
-      !line.trim().startsWith("|") &&
-      line.includes("|")
-    ) {
-      stitched[stitched.length - 1] = prev + line;
-    } else {
-      stitched.push(line);
+    const prevTrim = prev !== undefined ? prev.trim() : "";
+    const prevIsIncomplete = prevTrim.startsWith("|") && !prevTrim.endsWith("|");
+
+    if (prevIsIncomplete) {
+      if (trimmed === "") {
+        // Blank line inside a broken row — absorb it and keep waiting for the rest
+        continue;
+      }
+      if (trimmed.includes("|")) {
+        // Continuation (starting with | or not) — stitch into the pending row
+        stitched[stitched.length - 1] =
+          prev! + (trimmed.startsWith("|") ? trimmed : line);
+        continue;
+      }
     }
+
+    stitched.push(line);
   }
 
   // Pass 2: detect and normalize table blocks.

--- a/src/wecom_msg_adapter/markdown_adapter.ts
+++ b/src/wecom_msg_adapter/markdown_adapter.ts
@@ -204,24 +204,46 @@ function flattenDeepNesting(text: string): string {
 }
 
 function normalizeTables(text: string): string {
-  const lines = text.split("\n");
+  // Pass 1: stitch broken table rows back together.
+  // Models sometimes split a single row across two lines: the first starts
+  // with | but does not end with |, and the second is a continuation that
+  // doesn't start with |.  Re-join them before block detection.
+  const rawLines = text.split("\n");
+  const stitched: string[] = [];
+
+  for (const line of rawLines) {
+    const prev = stitched[stitched.length - 1];
+    if (
+      prev !== undefined &&
+      prev.trim().startsWith("|") &&
+      !prev.trim().endsWith("|") &&
+      !line.trim().startsWith("|") &&
+      line.includes("|")
+    ) {
+      stitched[stitched.length - 1] = prev + line;
+    } else {
+      stitched.push(line);
+    }
+  }
+
+  // Pass 2: detect and normalize table blocks.
   const out: string[] = [];
   let i = 0;
 
-  while (i < lines.length) {
-    if (looksLikeTableRow(lines[i]!)) {
-      const tableBlock = [lines[i]!];
+  while (i < stitched.length) {
+    if (looksLikeTableRow(stitched[i]!)) {
+      const tableBlock: string[] = [stitched[i]!];
       let j = i + 1;
 
-      while (j < lines.length && looksLikeTableRow(lines[j]!)) {
-        tableBlock.push(lines[j]!);
+      while (j < stitched.length && looksLikeTableRow(stitched[j]!)) {
+        tableBlock.push(stitched[j]!);
         j += 1;
       }
 
       out.push(...normalizeTableBlock(tableBlock));
       i = j;
     } else {
-      out.push(lines[i]!);
+      out.push(stitched[i]!);
       i += 1;
     }
   }
@@ -231,7 +253,9 @@ function normalizeTables(text: string): string {
 
 function looksLikeTableRow(line: string): boolean {
   const stripped = String(line).trim();
-  if (!stripped.includes("|")) return false;
+  // Must start with | — this rules out continuation fragments and avoids
+  // false positives on lines that merely contain a pipe character.
+  if (!stripped.startsWith("|")) return false;
   return (stripped.match(/\|/g) || []).length >= 2;
 }
 
@@ -253,6 +277,9 @@ function normalizeTableBlock(lines: string[]): string[] {
       parts = parts.slice(0, -1);
       right = " |";
     }
+
+    // Normalise alignment markers in separator rows (:---:, :---, ---:) → ---
+    parts = parts.map(p => (/^:?-+:?$/.test(p) ? "---" : p));
 
     return left + parts.join(" | ") + right;
   });


### PR DESCRIPTION
加了一个后处理，把模型输出markdown内容 reformat 到企业微信支持的markdown_v2格式。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bot messages sent via WeCom now automatically convert to WeCom Markdown V2 format for improved compatibility and consistent rendering. Message content is intelligently processed to normalize markdown syntax, remove unsupported elements, handle code blocks and images appropriately, and ensure optimal display in WeCom while respecting platform message length limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->