### PR TITLE
修复 WeCom webhook 入站文件进入会话工作区时被固定 5MB 限制拦截的问题

### DIFF
--- a/src/capability/bot/sandbox-media.test.ts
+++ b/src/capability/bot/sandbox-media.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { stageWecomInboundMediaForSession } from "./sandbox-media.js";
 
@@ -13,6 +13,7 @@ describe("stageWecomInboundMediaForSession", () => {
   });
 
   afterEach(async () => {
+    vi.unstubAllEnvs();
     await rm(root, { recursive: true, force: true });
   });
 
@@ -65,6 +66,54 @@ describe("stageWecomInboundMediaForSession", () => {
     expect(stagedBuffer.byteLength).toBe(6 * 1024 * 1024);
   });
 
+  it("uses the default sandbox workspace root when workspaceRoot is omitted", async () => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", root);
+    const mediaPath = path.join(root, "openclaw-media", "inbound", "default-root.bin");
+    const agentWorkspace = path.join(root, "agent-workspace");
+
+    await mkdir(path.dirname(mediaPath), { recursive: true });
+    await mkdir(agentWorkspace, { recursive: true });
+    await writeFile(mediaPath, Buffer.alloc(2 * 1024 * 1024, 5));
+
+    const staged = await stageWecomInboundMediaForSession({
+      cfg: {
+        channels: {
+          wecom: {
+            mediaMaxMb: 8,
+          },
+        },
+        agents: {
+          list: [
+            {
+              id: "ops",
+              workspace: agentWorkspace,
+              sandbox: {
+                mode: "non-main",
+                scope: "session",
+                workspaceAccess: "ro",
+                docker: {
+                  workdir: "/workspace",
+                },
+              },
+            },
+          ],
+        },
+      } as any,
+      accountId: "default",
+      agentId: "ops",
+      sessionKey: "agent:ops:wecom:default:dm:lisi",
+      mediaPath,
+      filename: "default-root.bin",
+    });
+
+    expect(staged).toMatch(/^media\/inbound\/default-root\.bin$/);
+    const sandboxEntries = await readdir(path.join(root, "sandboxes"));
+    const stagedBuffer = await readFile(
+      path.join(root, "sandboxes", sandboxEntries[0]!, "media", "inbound", "default-root.bin"),
+    );
+    expect(stagedBuffer.byteLength).toBe(2 * 1024 * 1024);
+  });
+
   it("stages inbound media into the agent workspace for non-sandbox sessions", async () => {
     const mediaPath = path.join(root, "openclaw-media", "inbound", "small.bin");
     const agentWorkspace = path.join(root, "agent-workspace");
@@ -108,5 +157,65 @@ describe("stageWecomInboundMediaForSession", () => {
     expect(staged).toBe(path.join(agentWorkspace, "media", "inbound", "small.bin"));
     const stagedBuffer = await readFile(staged);
     expect(stagedBuffer.byteLength).toBe(1024);
+  });
+
+  it("allocates distinct staged filenames for concurrent same-name uploads", async () => {
+    const mediaPathA = path.join(root, "openclaw-media", "inbound", "dup-a.bin");
+    const mediaPathB = path.join(root, "openclaw-media", "inbound", "dup-b.bin");
+    const agentWorkspace = path.join(root, "agent-workspace");
+
+    await mkdir(path.dirname(mediaPathA), { recursive: true });
+    await mkdir(agentWorkspace, { recursive: true });
+    await writeFile(mediaPathA, Buffer.from("first"));
+    await writeFile(mediaPathB, Buffer.from("second"));
+
+    const cfg = {
+      channels: {
+        wecom: {
+          mediaMaxMb: 8,
+        },
+      },
+      agents: {
+        list: [
+          {
+            id: "ops",
+            workspace: agentWorkspace,
+            sandbox: {
+              mode: "off",
+              scope: "session",
+              workspaceAccess: "ro",
+              docker: {
+                workdir: "/workspace",
+              },
+            },
+          },
+        ],
+      },
+    } as any;
+
+    const [stagedA, stagedB] = await Promise.all([
+      stageWecomInboundMediaForSession({
+        cfg,
+        accountId: "default",
+        agentId: "ops",
+        sessionKey: "agent:ops:wecom:default:dm:zhangsan",
+        mediaPath: mediaPathA,
+        filename: "dup.bin",
+      }),
+      stageWecomInboundMediaForSession({
+        cfg,
+        accountId: "default",
+        agentId: "ops",
+        sessionKey: "agent:ops:wecom:default:dm:lisi",
+        mediaPath: mediaPathB,
+        filename: "dup.bin",
+      }),
+    ]);
+
+    expect(stagedA).not.toBe(stagedB);
+    expect([path.basename(stagedA), path.basename(stagedB)].sort()).toEqual(["dup-1.bin", "dup.bin"]);
+    expect((await readFile(stagedA)).toString()).toMatch(/first|second/);
+    expect((await readFile(stagedB)).toString()).toMatch(/first|second/);
+    expect((await readFile(stagedA)).toString()).not.toBe((await readFile(stagedB)).toString());
   });
 });

--- a/src/capability/bot/sandbox-media.test.ts
+++ b/src/capability/bot/sandbox-media.test.ts
@@ -1,0 +1,112 @@
+import path from "node:path";
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { stageWecomInboundMediaForSession } from "./sandbox-media.js";
+
+describe("stageWecomInboundMediaForSession", () => {
+  const root = path.join("/tmp", `wecom-sandbox-stage-${process.pid}`);
+
+  beforeEach(async () => {
+    await mkdir(root, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("stages inbound media into the session sandbox workspace using channels.wecom.mediaMaxMb", async () => {
+    const mediaPath = path.join(root, "openclaw-media", "inbound", "big.bin");
+    const agentWorkspace = path.join(root, "agent-workspace");
+    const sandboxRoot = path.join(root, "sandboxes");
+
+    await mkdir(path.dirname(mediaPath), { recursive: true });
+    await mkdir(agentWorkspace, { recursive: true });
+    await writeFile(mediaPath, Buffer.alloc(6 * 1024 * 1024, 7));
+
+    const staged = await stageWecomInboundMediaForSession({
+      cfg: {
+        channels: {
+          wecom: {
+            mediaMaxMb: 8,
+          },
+        },
+        agents: {
+          list: [
+            {
+              id: "ops",
+              workspace: agentWorkspace,
+              sandbox: {
+                mode: "non-main",
+                scope: "session",
+                workspaceRoot: sandboxRoot,
+                workspaceAccess: "ro",
+                docker: {
+                  workdir: "/workspace",
+                },
+              },
+            },
+          ],
+        },
+      } as any,
+      accountId: "default",
+      agentId: "ops",
+      sessionKey: "agent:ops:wecom:default:dm:zhangsan",
+      mediaPath,
+      filename: "big.bin",
+    });
+
+    expect(staged).toMatch(/^media\/inbound\/big\.bin$/);
+    const sandboxEntries = await readdir(sandboxRoot);
+    const stagedBuffer = await readFile(
+      path.join(sandboxRoot, sandboxEntries[0]!, "media", "inbound", "big.bin"),
+    );
+    expect(stagedBuffer.byteLength).toBe(6 * 1024 * 1024);
+  });
+
+  it("stages inbound media into the agent workspace for non-sandbox sessions", async () => {
+    const mediaPath = path.join(root, "openclaw-media", "inbound", "small.bin");
+    const agentWorkspace = path.join(root, "agent-workspace");
+
+    await mkdir(path.dirname(mediaPath), { recursive: true });
+    await mkdir(agentWorkspace, { recursive: true });
+    await writeFile(mediaPath, Buffer.alloc(1024, 1));
+
+    const staged = await stageWecomInboundMediaForSession({
+      cfg: {
+        channels: {
+          wecom: {
+            mediaMaxMb: 8,
+          },
+        },
+        agents: {
+          list: [
+            {
+              id: "ops",
+              workspace: agentWorkspace,
+              sandbox: {
+                mode: "off",
+                scope: "session",
+                workspaceRoot: path.join(root, "sandboxes"),
+                workspaceAccess: "ro",
+                docker: {
+                  workdir: "/workspace",
+                },
+              },
+            },
+          ],
+        },
+      } as any,
+      accountId: "default",
+      agentId: "ops",
+      sessionKey: "agent:ops:wecom:default:dm:zhangsan",
+      mediaPath,
+      filename: "small.bin",
+    });
+
+    expect(staged).toBe(path.join(agentWorkspace, "media", "inbound", "small.bin"));
+    const stagedBuffer = await readFile(staged);
+    expect(stagedBuffer.byteLength).toBe(1024);
+  });
+});

--- a/src/capability/bot/sandbox-media.ts
+++ b/src/capability/bot/sandbox-media.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { constants } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { copyFile, mkdir, stat } from "node:fs/promises";
@@ -12,6 +13,14 @@ function expandHomeDir(input: string): string {
   if (input === "~") return os.homedir();
   if (input.startsWith("~/")) return path.join(os.homedir(), input.slice(2));
   return input;
+}
+
+function resolveOpenClawStateDir(): string {
+  const override = process.env.OPENCLAW_STATE_DIR?.trim() || process.env.CLAWDBOT_STATE_DIR?.trim();
+  if (override) {
+    return path.resolve(expandHomeDir(override));
+  }
+  return path.join(os.homedir(), ".openclaw");
 }
 
 function normalizeAgentId(agentId: string): string {
@@ -71,8 +80,14 @@ function resolveSessionWorkspaceTarget(params: {
     };
   }
   if (sandbox.workspaceAccess === "rw" || !sandbox.workspaceRoot) {
+    if (sandbox.workspaceAccess === "rw") {
+      return {
+        workspaceDir: agentWorkspaceDir,
+        sandboxed: true,
+      };
+    }
     return {
-      workspaceDir: agentWorkspaceDir,
+      workspaceDir: path.join(resolveOpenClawStateDir(), "sandboxes", slugifySessionKey(params.sessionKey.trim() || "main")),
       sandboxed: true,
     };
   }
@@ -96,7 +111,15 @@ function resolveSessionWorkspaceTarget(params: {
   };
 }
 
-async function allocateWorkspaceInboundFile(params: {
+function buildStagedFilenameCandidate(parsed: path.ParsedPath, suffix: number): string {
+  if (suffix === 0) {
+    return parsed.base || "attachment";
+  }
+  return `${parsed.name || "attachment"}-${suffix}${parsed.ext}`;
+}
+
+async function copyIntoWorkspaceInbound(params: {
+  sourcePath: string;
   workspaceDir: string;
   filename: string;
 }): Promise<{ absolutePath: string; relativePath: string }> {
@@ -104,20 +127,20 @@ async function allocateWorkspaceInboundFile(params: {
   await mkdir(inboundDir, { recursive: true });
 
   const parsed = path.parse(params.filename);
-  const baseName = parsed.base || "attachment";
-  let candidate = baseName;
-  let suffix = 1;
-  for (;;) {
+  for (let suffix = 0; ; suffix += 1) {
+    const candidate = buildStagedFilenameCandidate(parsed, suffix);
     const absolutePath = path.join(inboundDir, candidate);
     try {
-      await stat(absolutePath);
-      candidate = `${parsed.name || "attachment"}-${suffix}${parsed.ext}`;
-      suffix += 1;
-    } catch {
+      await copyFile(params.sourcePath, absolutePath, constants.COPYFILE_EXCL);
       return {
         absolutePath,
         relativePath: path.posix.join("media", "inbound", candidate),
       };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code === "EEXIST") {
+        continue;
+      }
+      throw error;
     }
   }
 }
@@ -144,10 +167,10 @@ export async function stageWecomInboundMediaForSession(params: {
     );
   }
 
-  const staged = await allocateWorkspaceInboundFile({
+  const staged = await copyIntoWorkspaceInbound({
+    sourcePath: params.mediaPath,
     workspaceDir: target.workspaceDir,
     filename: params.filename || path.basename(params.mediaPath),
   });
-  await copyFile(params.mediaPath, staged.absolutePath);
   return target.sandboxed ? staged.relativePath : staged.absolutePath;
 }

--- a/src/capability/bot/sandbox-media.ts
+++ b/src/capability/bot/sandbox-media.ts
@@ -1,0 +1,153 @@
+import crypto from "node:crypto";
+import os from "node:os";
+import path from "node:path";
+import { copyFile, mkdir, stat } from "node:fs/promises";
+
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { resolveAgentConfig, resolveAgentWorkspaceDir } from "openclaw/plugin-sdk/agent-runtime";
+
+import { resolveWecomMediaMaxBytes } from "../../config/index.js";
+
+function expandHomeDir(input: string): string {
+  if (input === "~") return os.homedir();
+  if (input.startsWith("~/")) return path.join(os.homedir(), input.slice(2));
+  return input;
+}
+
+function normalizeAgentId(agentId: string): string {
+  return agentId.trim().toLowerCase() || "main";
+}
+
+function normalizeMainKey(mainKey: unknown): string {
+  return typeof mainKey === "string" && mainKey.trim() ? mainKey.trim().toLowerCase() : "main";
+}
+
+function buildAgentMainSessionKey(cfg: OpenClawConfig, agentId: string): string {
+  if (cfg.session?.scope === "global") {
+    return "global";
+  }
+  return `agent:${normalizeAgentId(agentId)}:${normalizeMainKey(cfg.session?.mainKey)}`;
+}
+
+function slugifySessionKey(value: string): string {
+  const trimmed = value.trim() || "session";
+  const hash = crypto.createHash("sha256").update(trimmed).digest("hex").slice(0, 8);
+  const prefix =
+    trimmed
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 32) || "session";
+  return `${prefix}-${hash}`;
+}
+
+function isSandboxedSession(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey: string;
+}): boolean {
+  const sandbox = resolveAgentConfig(params.cfg, params.agentId)?.sandbox;
+  if (!sandbox || sandbox.mode === "off") {
+    return false;
+  }
+  if (sandbox.mode === "all") {
+    return true;
+  }
+  return params.sessionKey.trim().toLowerCase() !== buildAgentMainSessionKey(params.cfg, params.agentId);
+}
+
+function resolveSessionWorkspaceTarget(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey: string;
+}): { workspaceDir: string; sandboxed: boolean } {
+  const sandbox = resolveAgentConfig(params.cfg, params.agentId)?.sandbox;
+  const agentWorkspaceDirRaw = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+  const agentWorkspaceDir = path.resolve(expandHomeDir(agentWorkspaceDirRaw || process.cwd()));
+  if (!sandbox || !isSandboxedSession(params)) {
+    return {
+      workspaceDir: agentWorkspaceDir,
+      sandboxed: false,
+    };
+  }
+  if (sandbox.workspaceAccess === "rw" || !sandbox.workspaceRoot) {
+    return {
+      workspaceDir: agentWorkspaceDir,
+      sandboxed: true,
+    };
+  }
+
+  const workspaceRoot = path.resolve(expandHomeDir(sandbox.workspaceRoot));
+  const scopeKey =
+    sandbox.scope === "shared"
+      ? "shared"
+      : sandbox.scope === "session"
+        ? params.sessionKey.trim() || "main"
+        : `agent:${normalizeAgentId(params.agentId)}`;
+  if (sandbox.scope === "shared") {
+    return {
+      workspaceDir: workspaceRoot,
+      sandboxed: true,
+    };
+  }
+  return {
+    workspaceDir: path.join(workspaceRoot, slugifySessionKey(scopeKey)),
+    sandboxed: true,
+  };
+}
+
+async function allocateWorkspaceInboundFile(params: {
+  workspaceDir: string;
+  filename: string;
+}): Promise<{ absolutePath: string; relativePath: string }> {
+  const inboundDir = path.join(params.workspaceDir, "media", "inbound");
+  await mkdir(inboundDir, { recursive: true });
+
+  const parsed = path.parse(params.filename);
+  const baseName = parsed.base || "attachment";
+  let candidate = baseName;
+  let suffix = 1;
+  for (;;) {
+    const absolutePath = path.join(inboundDir, candidate);
+    try {
+      await stat(absolutePath);
+      candidate = `${parsed.name || "attachment"}-${suffix}${parsed.ext}`;
+      suffix += 1;
+    } catch {
+      return {
+        absolutePath,
+        relativePath: path.posix.join("media", "inbound", candidate),
+      };
+    }
+  }
+}
+
+export async function stageWecomInboundMediaForSession(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  agentId: string;
+  sessionKey: string;
+  mediaPath: string;
+  filename?: string;
+}): Promise<string> {
+  const target = resolveSessionWorkspaceTarget({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+  });
+
+  const maxBytes = resolveWecomMediaMaxBytes(params.cfg, params.accountId);
+  const sourceStat = await stat(params.mediaPath);
+  if (sourceStat.size > maxBytes) {
+    throw new Error(
+      `Inbound media size ${(sourceStat.size / (1024 * 1024)).toFixed(2)}MB exceeds channels.wecom.mediaMaxMb ${(maxBytes / (1024 * 1024)).toFixed(2)}MB before workspace staging`,
+    );
+  }
+
+  const staged = await allocateWorkspaceInboundFile({
+    workspaceDir: target.workspaceDir,
+    filename: params.filename || path.basename(params.mediaPath),
+  });
+  await copyFile(params.mediaPath, staged.absolutePath);
+  return target.sandboxed ? staged.relativePath : staged.absolutePath;
+}

--- a/src/capability/bot/stream-orchestrator.ts
+++ b/src/capability/bot/stream-orchestrator.ts
@@ -16,6 +16,7 @@ import { buildWecomBotDispatchConfig } from "./dispatch-config.js";
 import { sendBotFallbackPromptNow } from "./fallback-delivery.js";
 import { finalizeBotStream } from "./stream-finalizer.js";
 import { handleDirectLocalPathIntent } from "./local-path-delivery.js";
+import { stageWecomInboundMediaForSession } from "./sandbox-media.js";
 import { createBotReplyDispatcher } from "./stream-delivery.js";
 import type { BotRuntimeLogger, RecordBotOperationalEvent } from "./types.js";
 
@@ -152,6 +153,7 @@ export function createBotStreamOrchestrator(params: {
 
     let mediaPath: string | undefined;
     let mediaType: string | undefined;
+    const mediaFilename = media?.filename;
     if (media) {
       try {
         const maxBytes = resolveWecomMediaMaxBytes(target.config, target.account.accountId);
@@ -203,6 +205,23 @@ export function createBotStreamOrchestrator(params: {
       route.sessionKey = `agent:${targetAgentId}:wecom:${account.accountId}:${chatType === "group" ? "group" : "dm"}:${chatId}`;
       ensureDynamicAgentListed(targetAgentId, core).catch(() => { });
       logVerbose(target, `dynamic agent routing: ${targetAgentId}, sessionKey=${route.sessionKey}`);
+    }
+
+    if (mediaPath) {
+      try {
+        const stagedSessionPath = await stageWecomInboundMediaForSession({
+          cfg: target.config,
+          accountId: target.account.accountId,
+          agentId: route.agentId,
+          sessionKey: route.sessionKey,
+          mediaPath,
+          filename: mediaFilename,
+        });
+        mediaPath = stagedSessionPath;
+        logVerbose(target, `session media staged to ${mediaPath}`);
+      } catch (err) {
+        target.runtime.error?.(`Failed to stage inbound media for session workspace: ${String(err)}`);
+      }
     }
 
     logVerbose(target, `starting agent processing (streamId=${streamId}, agentId=${route.agentId}, peerKind=${chatType}, peerId=${chatId})`);


### PR DESCRIPTION
## 背景

  WeCom webhook 入站文件在当前实现里会先被插件保存，但后续进入会话工作区时还会走
  OpenClaw core 内部的一条固定 5MB staging 逻辑。

  这会导致：

  - 5MB 以下文件可以正常出现在目标 workspace
  - 5MB 以上文件虽然已经被插件接收，但不会进入当前会话工作区

  ## 本次改动

  不修改 OpenClaw core，只在 WeCom 插件侧修复这条链路：

  - webhook 入站媒体仍先按 `channels.wecom.mediaMaxMb` 保存
  - 然后由插件主动把文件放入当前会话工作区的 `media/inbound`
  - 再把 `MediaPath` 指向工作区中的 staged 文件
    - sandbox 会话使用 workspace 相对路径
    - 非 sandbox 会话使用工作区内绝对路径

  ## 影响范围

  只影响 WeCom webhook 入站附件进入当前会话工作区这一条链路。

  不涉及：

  - OpenClaw core 源码
  - outbound / 上传回企微
  - Bot WS 发送链路
  - 其他无关功能

  ## 验证

  已本地验证及单元测试通过：

  ```bash
  npx tsc -p tsconfig.json --noEmit
  npx vitest run --config /tmp/wecom-vitest.config.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic staging of incoming WeCom media into per-session workspaces, honoring sandbox mode and size limits so media is placed where it’s safe and accessible.
  * Attachments and message context now reference the staged media location when staging succeeds.

* **Tests**
  * Added comprehensive tests covering staging behavior across sandbox modes, workspace configurations, size limits, and concurrent uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->