### PR TITLE
feat(wecom): 添加自建应用渠道创建菜单点击事件调用本地脚本的功能，收到event后可以根据配置路由到指定脚本

### DIFF
--- a/MENU_EVENT_CONF.md
+++ b/MENU_EVENT_CONF.md
@@ -1,0 +1,500 @@
+# 企业微信自定义菜单与 Click 事件配置指南
+
+## 概述
+
+本文档介绍如何在 OpenClaw 企业微信插件中配置自定义菜单，并处理 click 类型按钮的事件。
+
+## 创建菜单
+
+### API 接口
+
+```
+POST https://qyapi.weixin.qq.com/cgi-bin/menu/create?access_token=ACCESS_TOKEN&agentid=AGENTID
+```
+
+### 菜单结构示例
+
+```json
+{
+  "button": [
+    {
+      "type": "click",
+      "name": "Python测试",
+      "key": "TEST_CLICK_PY"
+    },
+    {
+      "type": "click",
+      "name": "Node测试",
+      "key": "TEST_CLICK_JS"
+    },
+    {
+      "name": "更多",
+      "sub_button": [
+        {
+          "type": "view",
+          "name": "打开网页",
+          "url": "https://work.weixin.qq.com"
+        },
+        {
+          "type": "click",
+          "name": "菜单信息",
+          "key": "MENU_INFO"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 支持的按钮类型
+
+| 类型 | 说明 |
+|------|------|
+| `click` | 点击推事件，触发事件推送 |
+| `view` | 跳转URL，打开网页 |
+| `scancode_push` | 扫码推事件 |
+| `scancode_waitmsg` | 扫码推事件且弹出提示框 |
+| `pic_sysphoto` | 弹出系统拍照发图 |
+| `pic_photo_or_album` | 弹出拍照或者相册发图 |
+| `pic_weixin` | 弹出企业微信相册发图器 |
+| `location_select` | 弹出地理位置选择器 |
+| `view_miniprogram` | 跳转到小程序 |
+
+## 配置事件路由
+
+在 `openclaw.json` 中配置 `eventRouting` 和 `scriptRuntime`：
+
+```json
+{
+  "channels": {
+    "wecom": {
+      "accounts": {
+        "your-account": {
+          "agent": {
+            "eventRouting": {
+              "unmatchedAction": "forwardToAgent",
+              "routes": [
+                {
+                  "id": "test-click-python",
+                  "when": { 
+                    "eventType": "click", 
+                    "eventKey": "TEST_CLICK_PY" 
+                  },
+                  "handler": { 
+                    "type": "python_script", 
+                    "entry": "/path/to/script.py" 
+                  }
+                },
+                {
+                  "id": "test-click-js",
+                  "when": { 
+                    "eventType": "click", 
+                    "eventKey": "TEST_CLICK_JS" 
+                  },
+                  "handler": { 
+                    "type": "node_script", 
+                    "entry": "/path/to/script.mjs" 
+                  }
+                },
+                {
+                  "id": "menu-info-echo",
+                  "when": { 
+                    "eventType": "click", 
+                    "eventKey": "MENU_INFO" 
+                  },
+                  "handler": { 
+                    "type": "builtin", 
+                    "name": "echo" 
+                  }
+                }
+              ]
+            },
+            "scriptRuntime": {
+              "enabled": true,
+              "allowPaths": ["/path/to/scripts"],
+              "defaultTimeoutMs": 10000,
+              "pythonCommand": "python3",
+              "nodeCommand": "node"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## 事件路由配置说明
+
+### unmatchedAction（未匹配事件的处理方式）
+
+当收到的事件**没有匹配任何路由**时，由 `unmatchedAction` 决定如何处理：
+
+- `ignore` - 未匹配的事件直接忽略，不处理也不回复
+- `forwardToAgent` - 未匹配的事件传递给 Agent（AI）处理
+
+**注意：** 这个配置只影响**未匹配路由**的事件。如果事件匹配了路由，则由路由的 handler 决定后续行为。
+
+### 路由匹配条件 (when)
+
+| 字段 | 说明 |
+|------|------|
+| `eventType` | 事件类型，如 `click`、`change_contact` |
+| `eventKey` | 精确匹配事件 key |
+| `eventKeyPrefix` | 前缀匹配事件 key |
+| `eventKeyPattern` | 正则匹配事件 key |
+| `changeType` | 通讯录变更类型，如 `create_user` |
+
+### Handler 类型
+
+| 类型 | 说明 |
+|------|------|
+| `builtin` | 内置处理器，目前支持 `echo` |
+| `node_script` | Node.js 脚本 |
+| `python_script` | Python 脚本 |
+
+### `chainToAgent` 的两个来源
+
+`chainToAgent` 现在只表达一个意思：当前事件处理完成后，是否继续进入默认 Agent（AI）流程。
+
+这个开关有两个输入来源，但它们控制的是同一件事，不是两个不同功能：
+
+#### 1. Handler 配置里的 `chainToAgent`
+
+在 `openclaw.json` 的 handler 中配置：
+
+```json
+{
+  "handler": {
+    "type": "python_script",
+    "entry": "/path/to/script.py",
+    "chainToAgent": true
+  }
+}
+```
+
+**特点：**
+- 这是静态配置，适合声明“这条路由处理完后一定继续走 Agent”
+- 只有设为 `true` 才会产生强制效果
+- 设为 `false` 和不写，在当前实现里效果相同，都不会阻止脚本返回 `true`
+
+#### 2. 脚本返回里的 `chainToAgent`
+
+脚本通过 stdout 返回 JSON：
+
+```json
+{
+  "ok": true,
+  "action": "reply_text",
+  "reply": {
+    "text": "回复内容"
+  },
+  "chainToAgent": false  // 脚本动态决定
+}
+```
+
+**特点：**
+- 这是动态决策，适合脚本根据业务条件决定是否继续走 Agent
+- 当 handler 没有把 `chainToAgent` 设为 `true` 时，以脚本返回为准
+- 如果脚本不返回该字段，默认为 `false`
+
+#### 实际合并规则
+
+代码中的最终判断等价于：
+
+```ts
+finalChainToAgent =
+  handler.chainToAgent === true || scriptResponse.chainToAgent === true;
+```
+
+可以把它理解为：
+
+- `handler.chainToAgent` 是“静态放行开关”
+- `scriptResponse.chainToAgent` 是“脚本运行后的动态放行结果”
+- 任意一方明确返回 `true`，都会继续进入默认 Agent 流程
+- 两边都不是 `true` 时，才会在当前路由处理后结束
+
+#### 行为总结
+
+| Handler 配置 | 脚本返回 | 最终行为 |
+|-------------|---------|---------|
+| `true` | `false` | `true` |
+| `true` | `true` | `true` |
+| `false` | `true` | `true` |
+| 未设置 | `true` | `true` |
+| 未设置 / `false` | `false` | `false` |
+| 未设置 / `false` | 未返回 | `false` |
+
+**关键点：** 当前实现里不存在“`false` 覆盖 `true`”。只有 `true` 会向上抬高最终结果。
+
+#### 推荐做法
+
+**场景 1：脚本完全控制**
+- Handler 配置中**不设置** `chainToAgent`
+- 脚本根据需要返回 `true` 或 `false`
+
+```json
+// openclaw.json
+"handler": {
+  "type": "python_script",
+  "entry": "/path/to/script.py"
+  // 不写 chainToAgent
+}
+```
+
+```python
+# script.py - 动态决定
+if some_condition:
+    response["chainToAgent"] = True  # 继续 AI 处理
+else:
+    response["chainToAgent"] = False  # 到此结束
+```
+
+**场景 2：固定继续走 Agent**
+- Handler 配置中设置 `"chainToAgent": true`
+- 此时即使脚本返回 `false`，最终仍会继续进入默认 Agent 流程
+
+```json
+// openclaw.json - 固定走 AI 流程
+"handler": {
+  "type": "python_script",
+  "entry": "/path/to/script.py",
+  "chainToAgent": true
+}
+```
+
+**场景 3：固定不继续走 Agent**
+- 不要依赖 handler 里的 `"chainToAgent": false`
+- 应该保持 handler 不写该字段，并让脚本稳定返回 `false`
+
+也就是说：
+
+- 想“固定继续”，可以用 handler 配置 `true`
+- 想“固定停止”，应由脚本返回 `false` 来保证
+
+## 脚本编写规范
+
+脚本通过 `stdin` 接收 JSON 数据，通过 `stdout` 返回 JSON 响应。
+
+### 输入格式 (envelope)
+
+```json
+{
+  "version": "1.0",
+  "channel": "wecom",
+  "accountId": "blue",
+  "receivedAt": 1775963707523,
+  "message": {
+    "msgType": "event",
+    "eventType": "click",
+    "eventKey": "TEST_CLICK_PY",
+    "changeType": null,
+    "fromUser": "GuanXiaoPeng",
+    "toUser": "corp-id",
+    "chatId": null,
+    "agentId": 1000015,
+    "createTime": 1775963707,
+    "msgId": "msg-id",
+    "raw": { /* 原始 XML 解析数据 */ }
+  },
+  "route": {
+    "matchedRuleId": "test-click-python",
+    "handlerType": "python_script"
+  }
+}
+```
+
+### 输出格式 (response)
+
+```json
+{
+  "ok": true,
+  "action": "reply_text",
+  "reply": {
+    "text": "回复内容"
+  },
+  "chainToAgent": false
+}
+```
+
+### action 类型
+
+- `none` - 不回复
+- `reply_text` - 回复文本消息
+
+### Python 脚本示例
+
+```python
+#!/usr/bin/env python3
+import json
+import sys
+
+def main():
+    payload = json.load(sys.stdin)
+    message = payload.get("message", {})
+    event_key = message.get("eventKey") or ""
+    from_user = message.get("fromUser", "")
+    
+    response = {
+        "ok": True,
+        "action": "reply_text",
+        "reply": {
+            "text": f"收到点击事件: {event_key}\n来自用户: {from_user}"
+        },
+        "chainToAgent": False
+    }
+    
+    json.dump(response, sys.stdout)
+
+if __name__ == "__main__":
+    main()
+```
+
+### Node.js 脚本示例
+
+```javascript
+#!/usr/bin/env node
+let raw = "";
+process.stdin.setEncoding("utf8");
+
+process.stdin.on("data", (chunk) => {
+  raw += chunk;
+});
+
+process.stdin.on("end", () => {
+  const payload = JSON.parse(raw || "{}");
+  const message = payload?.message ?? {};
+  const eventKey = message?.eventKey ?? "";
+  const fromUser = message?.fromUser ?? "";
+
+  const response = {
+    ok: true,
+    action: "reply_text",
+    reply: {
+      text: `收到点击事件: ${eventKey}\n来自用户: ${fromUser}`
+    },
+    chainToAgent: false
+  };
+
+  process.stdout.write(JSON.stringify(response));
+});
+```
+
+## 常见踩坑
+
+### 1. IP 白名单限制
+
+**错误信息：**
+```
+{"errcode": 60020, "errmsg": "not allow to access from your ip"}
+```
+
+**解决方案：**
+- 在企业微信管理后台配置可信 IP 列表
+- 或使用配置的代理服务器
+
+### 2. 菜单名称长度限制
+
+**错误信息：**
+```
+{"errcode": 40058, "errmsg": "button.name exceed max length 16"}
+```
+
+**解决方案：**
+- 一级菜单名称不超过 16 字节（约 16 个英文字符或 8 个中文字符）
+- 子菜单名称不超过 40 字节
+- 避免使用 emoji，会占用更多字节
+
+### 3. 脚本路径未授权
+
+**错误信息：**
+```
+script path is not allowed: /path/to/script.py
+```
+
+**解决方案：**
+- 确保脚本路径在 `scriptRuntime.allowPaths` 配置的目录下
+- 路径必须是绝对路径
+
+### 4. 脚本运行时未启用
+
+**错误信息：**
+```
+script runtime is disabled
+```
+
+**解决方案：**
+- 确保 `scriptRuntime.enabled` 设置为 `true`
+
+### 5. 脚本输出格式错误
+
+**错误信息：**
+```
+script output is not valid JSON
+```
+
+**解决方案：**
+- 确保脚本输出是有效的 JSON 格式
+- 不要输出调试信息到 stdout
+- 错误信息可以输出到 stderr
+
+### 6. 脚本执行超时
+
+**错误信息：**
+```
+script execution timed out after 5000ms
+```
+
+**解决方案：**
+- 增加 `timeoutMs` 配置（handler 级别或 `defaultTimeoutMs` 全局）
+- 优化脚本性能
+
+### 7. Access Token 过期
+
+**错误信息：**
+```
+{"errcode": 42001, "errmsg": "access_token expired"}
+```
+
+**解决方案：**
+- 重新获取 access_token
+- access_token 有效期为 2 小时
+
+### 8. 菜单不显示
+
+**可能原因：**
+- 应用未发布（需要发布后才对成员可见）
+- 成员不在应用可见范围内
+- 缓存问题（重新进入应用或等待几分钟）
+
+## 调试技巧
+
+### 1. 查看当前菜单
+
+```bash
+curl "https://qyapi.weixin.qq.com/cgi-bin/menu/get?access_token=TOKEN&agentid=AGENTID"
+```
+
+### 2. 删除菜单
+
+```bash
+curl "https://qyapi.weixin.qq.com/cgi-bin/menu/delete?access_token=TOKEN&agentid=AGENTID"
+```
+
+### 3. 本地测试脚本
+
+```bash
+# 准备测试数据
+echo '{"version":"1.0","channel":"wecom","accountId":"blue","message":{"eventType":"click","eventKey":"TEST","fromUser":"test"},"route":{"matchedRuleId":"test","handlerType":"python_script"}}' | python3 script.py
+```
+
+### 4. 查看 OpenClaw 日志
+
+```bash
+openclaw logs --tail 100
+```
+
+## 参考文档
+
+- [企业微信创建菜单 API](https://developer.work.weixin.qq.com/document/path/90231)
+- [企业微信接收事件推送](https://developer.work.weixin.qq.com/document/path/90240)

--- a/MENU_EVENT_PLAN.md
+++ b/MENU_EVENT_PLAN.md
@@ -1,0 +1,440 @@
+# WeCom 菜单事件可配置回调功能规划（PLAN）
+
+## 1. 背景与目标
+
+当前插件对 Agent 入站 `event` 使用固定白名单，未覆盖企业微信“菜单事件”全量场景（如 `click`、`view`、`scancode_push`、`location_select` 等）。
+
+目标是把“是否放行 event、放行哪些 eventType、由谁处理”从代码硬编码改为可配置：
+
+1. 支持在 OpenClaw 配置中声明是否启用 `event` 处理。
+2. 在 `event` 内支持按 `eventType` 白名单（例如只放行 `click`、`scancode_push`）。
+3. 每个事件可绑定处理器（内置 handler / 外部 TS/JS / 外部 Python）。
+4. 默认安全：不配置即保持现有行为兼容，不自动放通新增事件。
+
+## 2. 需求范围
+
+### 2.1 本期（MVP）
+
+1. 菜单点击类事件可配置放通：
+   - `click`
+   - `view`
+   - `view_miniprogram`
+   - `scancode_push`
+   - `scancode_waitmsg`
+   - `pic_sysphoto`
+   - `pic_photo_or_album`
+   - `pic_weixin`
+   - `location_select`
+2. 配置驱动白名单：`eventEnabled` + `eventType`。
+3. 事件分发器：按匹配规则将事件交给指定处理器。
+4. 脚本处理器能力：
+   - Node 脚本（TS/JS，先支持 JS，TS 通过 tsx/ts-node 作为可选）
+   - Python 脚本
+5. 统一执行输入输出协议（JSON stdin/stdout），并把接收到的 event 参数透传给外部脚本。
+6. 最小可观测能力：审计日志、超时、退出码、错误摘要。
+
+### 2.2 后续增强（非 MVP）
+
+1. 脚本热更新和缓存。
+2. 并发/速率限制（按事件类型或账号维度）。
+3. 幂等增强（事件去重键可配置）。
+4. 回调重试策略（指数退避 + 死信）。
+5. handler 沙箱隔离（容器/受限用户执行）。
+
+## 3. 设计原则
+
+1. 兼容优先：未新增配置时，行为与当前版本一致。
+2. 显式放通：只处理配置明确允许的类型。
+3. 最小权限：外部脚本执行能力默认关闭或仅允许受信目录。
+4. 可追踪：每次分发都可在日志中定位“为什么放通/为什么拒绝/由谁处理”。
+5. 可替换：处理器接口稳定，后续可新增 webhook/queue 等执行后端。
+
+## 3.1 事件格式盘点（基于文档 90240）
+
+按文档事件目录统计，建议全部纳入“可配置支持范围”，默认采用 deny by default（不放通）。
+
+### A. 一级事件格式数量
+
+共 17 类一级事件格式：
+
+1. 成员关注及取消关注事件
+2. 进入应用
+3. 上报地理位置
+4. 异步任务完成事件推送
+5. 通讯录变更事件
+6. 菜单事件
+7. 审批状态通知事件
+8. 企业互联共享应用事件回调
+9. 上下游共享应用事件回调
+10. 模板卡片事件推送
+11. 通用模板卡片右上角菜单事件推送
+12. 长期未使用应用停用预警事件
+13. 长期未使用应用临时停用事件
+14. 长期未使用应用重新启用事件
+15. 应用低活跃预警事件
+16. 低活跃应用事件
+17. 低活跃应用活跃恢复事件
+
+### B. Event 字段可枚举值数量
+
+共 26 个 Event 值（建议全部支持配置）：
+
+1. subscribe
+2. unsubscribe
+3. enter_agent
+4. LOCATION
+5. batch_job_result
+6. change_contact
+7. click
+8. view
+9. view_miniprogram
+10. scancode_push
+11. scancode_waitmsg
+12. pic_sysphoto
+13. pic_photo_or_album
+14. pic_weixin
+15. location_select
+16. open_approval_change
+17. share_agent_change
+18. share_chain_change
+19. template_card_event
+20. template_card_menu_event
+21. inactive_alert
+22. close_inactive_agent
+23. reopen_inactive_agent
+24. low_active_alert
+25. low_active
+26. active_restored
+
+### C. 含 ChangeType 的展开数量
+
+如果把 `change_contact` 按 `ChangeType` 展开，建议按“二级事件”管理，共 7 种：
+
+1. create_user
+2. update_user
+3. delete_user
+4. create_party
+5. update_party
+6. delete_party
+7. update_tag
+
+因此，配置层可支持的“可路由事件项”建议按 32 项预算：
+
+1. 26 个 Event 值
+2. 其中 change_contact 再细分 7 个 ChangeType（路由维度）
+
+### D. 配置建议（用于实现）
+
+1. 第一层：`eventEnabled`（开关，先解决“支持 event”）。
+2. 第二层：`eventType`（即 Event，用于主白名单和主路由）。
+3. 第三层：`changeType` 或 `eventKey`。
+   - `changeType`：仅当 `eventType=change_contact` 时启用。
+   - `eventKey`：菜单事件精细路由，支持精确值/前缀/正则。
+4. `messageType` 级别白名单作为后续扩展，不纳入本期 MVP 必选项。
+
+## 4. 配置模型草案
+
+建议在 `channels.wecom.accounts.<accountId>.agent` 下新增：
+
+```yaml
+channels:
+  wecom:
+    accounts:
+      default:
+        agent:
+               # 1) event 入站白名单配置（MVP）
+          inboundPolicy:
+                  eventEnabled: true
+            eventPolicy:
+              mode: allowlist
+              allowedEventTypes:
+                - subscribe
+                - enter_agent
+                - click
+                - view
+                - view_miniprogram
+                - scancode_push
+                - scancode_waitmsg
+                - pic_sysphoto
+                - pic_photo_or_album
+                - pic_weixin
+                - location_select
+
+          # 2) 事件分发配置
+          eventRouting:
+            unmatchedAction: ignore # ignore | forwardToAgent
+            routes:
+              - when:
+                  eventType: click
+                  eventKey: "MENU_HELP"
+                handler:
+                  type: node_script
+                  entry: "./scripts/wecom/menu-click-help.js"
+                  timeoutMs: 5000
+              - when:
+                  eventType: scancode_push
+                handler:
+                  type: python_script
+                  entry: "./scripts/wecom/scancode_handler.py"
+                  timeoutMs: 8000
+
+          # 3) 脚本执行安全设置
+          scriptRuntime:
+            enabled: true
+            allowPaths:
+              - "./scripts/wecom"
+            maxStdoutBytes: 262144
+            maxStderrBytes: 131072
+            defaultTimeoutMs: 5000
+            pythonCommand: "python3"
+            nodeCommand: "node"
+```
+
+## 5. 分发与执行架构
+
+### 5.1 处理链路
+
+1. 接收并解析 XML（现有能力）。
+2. 生成标准入站上下文 `InboundEventContext`。
+3. 先走 `inboundPolicy` 判定：
+   - 非 `event` 消息保持现状（按现有逻辑处理）。
+   - `eventEnabled=false` => 拒绝 event。
+   - `eventType` 不允许 => 拒绝。
+4. 命中后进入 `eventRouting`：
+   - 按 routes 顺序匹配（首个命中即执行）。
+   - 未命中走 `unmatchedAction`。
+5. 执行 handler：
+   - `builtin`：调用内置函数。
+   - `node_script`：子进程执行 Node 脚本。
+   - `python_script`：子进程执行 Python 脚本。
+6. 汇总 handler 结果，决定：
+   - 是否回复用户。
+   - 是否继续默认消息流水线。
+   - 是否仅记录审计并结束。
+
+### 5.2 统一处理器返回协议（建议）
+
+外部脚本输入（stdin）必须包含完整事件参数，至少包括标准字段 + 原始字段：
+
+```json
+{
+   "version": "1.0",
+   "channel": "wecom",
+   "accountId": "default",
+   "receivedAt": 1760000000000,
+   "message": {
+      "msgType": "event",
+      "eventType": "click",
+      "eventKey": "MENU_HELP",
+      "changeType": null,
+      "fromUser": "zhangsan",
+      "toUser": "wwxxxx",
+      "chatId": null,
+      "agentId": 1000002,
+      "createTime": 1760000000,
+      "msgId": null,
+      "raw": {
+         "ToUserName": "wwxxxx",
+         "FromUserName": "zhangsan",
+         "MsgType": "event",
+         "Event": "click",
+         "EventKey": "MENU_HELP",
+         "AgentID": "1000002"
+      }
+   },
+   "route": {
+      "matchedRuleId": "menu_help_click",
+      "handlerType": "node_script"
+   }
+}
+```
+
+说明：
+
+1. `message.raw` 为原始 XML 解析结果（扁平对象），用于外部脚本读取任意参数。
+2. `message` 顶层为标准化字段，降低脚本解析成本。
+3. 对菜单事件扩展字段（如 `ScanCodeInfo`、`SendPicsInfo`、`SendLocationInfo`）需原样放入 `message.raw`。
+4. 后续新增事件字段无需改协议版本，直接在 `message.raw` 增量透传。
+
+外部脚本从 stdout 返回 JSON：
+
+```json
+{
+  "ok": true,
+  "action": "reply_text",
+  "reply": {
+    "text": "已收到菜单点击: MENU_HELP"
+  },
+  "chainToAgent": false,
+  "audit": {
+    "tags": ["menu", "click"]
+  }
+}
+```
+
+字段建议：
+
+1. `ok`: boolean，处理是否成功。
+2. `action`: `none | reply_text | reply_markdown | call_internal`。
+3. `reply`: 回复负载。
+4. `chainToAgent`: 是否继续走默认 AI 会话。
+5. `audit`: 附加审计标签。
+6. `error`: 失败时错误消息。
+
+### 5.3 参数透传要求（强约束）
+
+1. 所有外部 handler（Node/Python）都必须收到完整 event 参数，不允许只传 `eventType/eventKey`。
+2. 参数透传应包含：基础字段、事件字段、扩展子结构、原始解析对象。
+3. 当字段缺失时保留 `null` 或空对象，不要静默删除键，避免脚本分支判断失效。
+4. 当入站不是 `event` 时，仍保持统一 envelope 结构，便于未来复用。
+
+## 6. 代码改造建议
+
+### 6.1 配置与类型
+
+1. 扩展配置类型：
+   - `src/types/config.ts`
+   - `src/config/schema.ts`
+2. 增加默认值与兼容合并逻辑：
+   - `src/config/runtime-config.ts`
+
+### 6.2 入站过滤改造
+
+1. 将当前 `shouldProcessAgentInboundMessage` 的硬编码白名单改为：
+   - 先判断 `inboundPolicy.eventEnabled`
+   - 对 `event` 再读 `eventPolicy.allowedEventTypes`
+2. 保留现有关键保护逻辑：
+   - `sys` 发送者保护
+   - 缺失 sender 保护
+   - 已有去重保护
+
+### 6.3 新增事件分发器
+
+建议新增模块：
+
+1. `src/agent/event-router.ts`
+   - 路由匹配
+   - handler 选择
+2. `src/agent/handler-runner.ts`
+   - builtin / node / python 统一执行
+   - 超时、stdout/stderr 限流
+   - stdin 注入标准 envelope（含完整 event 参数）
+3. `src/agent/handler-protocol.ts`
+   - 输入输出协议定义
+
+### 6.4 在主处理流程接入
+
+在 `src/agent/handler.ts` 的 `event` 分支：
+
+1. 在放通后优先调用事件分发器。
+2. 分发器返回 `handled=true` 且 `chainToAgent=false` 时，终止默认 AI 流程。
+3. 需要默认流程时继续原有 `processAgentMessage`。
+
+## 7. 安全与风险控制
+
+1. 默认关闭脚本执行，需显式 `scriptRuntime.enabled=true`。
+2. 仅允许执行 `allowPaths` 下脚本，防止任意路径执行。
+3. 进程级超时，超时强制 kill。
+4. 限制 stdout/stderr 最大字节，防止日志/内存膨胀。
+5. 子进程不继承敏感环境变量（可配置白名单透传）。
+6. 记录审计：账号、eventType、eventKey、handler、耗时、退出码。
+
+## 8. 测试计划
+
+### 8.1 单元测试
+
+1. `inboundPolicy` 判定测试：
+   - eventEnabled/eventType allow/deny 组合。
+2. `eventRouting` 匹配测试：
+   - eventType + changeType/eventKey 优先级。
+3. handler runner 测试：
+   - 正常输出
+   - 非法 JSON
+   - 超时
+   - 非 0 退出码
+   - stdin 中包含完整 event 参数与 raw 字段
+
+### 8.2 集成测试
+
+1. 构造 `click`、`view`、`scancode_push` XML 回调，验证完整链路。
+2. 验证 `unmatchedAction` 两种模式。
+3. 验证配置缺失时与当前版本行为一致。
+4. 验证外部脚本可读取 `ScanCodeInfo/SendPicsInfo/SendLocationInfo` 等扩展参数。
+
+### 8.3 回归测试
+
+1. `subscribe` / `enter_agent` 现有行为不回归。
+2. 文档/日程等现有 `doc_*`、`wedoc_*`、`smartsheet_*` 事件不回归。
+
+## 9. 里程碑与交付
+
+### M1：配置化放通（1~2 天）
+
+1. 完成配置 schema/type 扩展。
+2. `shouldProcessAgentInboundMessage` 改为 `eventEnabled + eventType` 配置驱动。
+3. 增加单元测试。
+
+### M2：事件分发器（2~3 天）
+
+1. 实现 route 匹配和 builtin handler。
+2. 接入主处理流程。
+3. 增加集成测试。
+
+### M3：外部脚本执行（2~3 天）
+
+1. Node/Python runner。
+2. 超时和输出限制。
+3. 审计字段补齐。
+
+### M4：文档与示例（1 天）
+
+1. README 增加配置示例与安全建议。
+2. 增加 `scripts/wecom` 示例脚本。
+
+#### M4 已落地内容（2026-04-10）
+
+1. 已在 README 增加 Agent 事件路由章节，包含：
+   - 三层配置示例（`eventEnabled -> eventType -> changeType/eventKey`）
+   - Node/Python handler 配置样例
+   - stdin/stdout 协议说明
+   - 安全建议
+2. 已新增可运行示例脚本：
+   - `scripts/wecom/menu-click-help.js`
+   - `scripts/wecom/menu-click-help.py`
+   - `scripts/wecom/README.md`
+3. 现状说明：
+   - M1 已完成：event 配置化放通
+   - M2 已完成：事件路由与 builtin handler
+   - M3 已完成：Node/Python runner + 超时/输出限制 + 审计
+   - M4 已完成：文档和示例交付
+
+## 10. 首批内置 handler 建议
+
+1. `menu_click_echo`：回显 `eventType` + `eventKey`，用于联调。
+2. `menu_click_route_to_prompt`：将菜单键映射成固定提示词进入默认 pipeline。
+3. `menu_click_call_script`：作为脚本执行桥接器。
+
+## 11. 兼容性策略
+
+1. 旧配置无 `inboundPolicy` 时，使用“兼容默认白名单”（与当前一致）。
+2. 新配置启用后，按配置优先生效。
+3. 对未识别配置字段仅告警不崩溃。
+
+## 11.1 为什么先不做 messageType 白名单
+
+1. 当前痛点集中在 `event` 被整体过滤，最小改动是先引入 `eventEnabled`。
+2. 现有 `text/image/file/...` 已在当前链路可处理，本期不需要额外开关干预。
+3. 先做 event 维度可显著降低配置复杂度与回归风险。
+4. 后续若出现“非 event 类型也需要细粒度开关”的需求，再增补 messageType 白名单。
+
+## 12. 开放问题（需确认）
+
+1. 菜单事件 `view/view_miniprogram` 是否默认只审计不触发回复？
+2. 脚本 handler 是否允许访问网络，是否需要开关控制？
+3. 是否需要在每个 route 上支持 `retryPolicy`？
+4. 是否需要支持 webhook handler（HTTP 回调）作为第三类外部处理器？
+
+---
+
+该规划优先保证“可配置放通 + 可扩展处理 + 安全默认值”。
+如果确认此方案，可按 M1 开始先落地配置化白名单，再逐步引入路由与脚本执行能力。

--- a/scripts/wecom/README.md
+++ b/scripts/wecom/README.md
@@ -1,0 +1,123 @@
+# WeCom 事件脚本示例
+
+本目录提供可直接运行的 WeCom Agent 事件路由脚本示例。
+
+## 文件说明
+
+- `menu-click-help.js`：Node.js 菜单点击事件示例。
+- `menu-click-help.py`：Python 菜单点击事件示例。
+
+## 输入协议
+
+脚本从 `stdin` 接收一份 JSON envelope。当前结构如下：
+
+```json
+{
+  "version": "1.0",
+  "channel": "wecom",
+  "accountId": "default",
+  "receivedAt": 1760000000000,
+  "message": {
+    "msgType": "event",
+    "eventType": "click",
+    "eventKey": "MENU_HELP",
+    "changeType": null,
+    "fromUser": "zhangsan",
+    "toUser": "wwxxxx",
+    "chatId": null,
+    "agentId": 1000001,
+    "createTime": 1760000000,
+    "msgId": "1234567890",
+    "raw": {
+      "ToUserName": "wwxxxx",
+      "FromUserName": "zhangsan",
+      "MsgType": "event",
+      "Event": "click",
+      "EventKey": "MENU_HELP",
+      "AgentID": "1000001"
+    }
+  },
+  "route": {
+    "matchedRuleId": "menu_help_click",
+    "handlerType": "node_script"
+  }
+}
+```
+
+### 输入字段说明
+
+- `version`：协议版本，当前固定为 `1.0`。
+- `channel`：渠道标识，当前固定为 `wecom`。
+- `accountId`：命中的企微账号 ID。
+- `receivedAt`：路由层接收事件时的毫秒时间戳。
+- `message.msgType`：消息类型，事件场景一般是 `event`。
+- `message.eventType`：事件类型（例如 `click`、`change_contact`）。
+- `message.eventKey`：事件键，可能为空。
+- `message.changeType`：二级事件类型，仅部分事件存在（例如 `change_contact`）。
+- `message.fromUser`：发送者 UserId。
+- `message.toUser`：接收方 corpId。
+- `message.chatId`：群聊 ID，单聊可能为 `null`。
+- `message.agentId`：应用 AgentID。
+- `message.createTime`：企微事件时间戳（秒）。
+- `message.msgId`：消息 ID，某些事件可能为 `null`。
+- `message.raw`：完整原始对象（XML 解析结果），新增字段会优先在这里透传。
+- `route.matchedRuleId`：命中的路由规则 ID。
+- `route.handlerType`：当前执行器类型（`node_script` 或 `python_script`）。
+
+## 输出协议
+
+脚本需要向 `stdout` 输出一份 JSON。当前支持的关键字段：
+
+- `ok`：可选，布尔值，表示脚本是否成功处理。
+- `action`：可选，当前支持 `none` 或 `reply_text`。
+- `reply.text`：当 `action=reply_text` 时使用，作为回复内容。
+- `chainToAgent`：可选，脚本侧动态决定是否继续进入默认 Agent（AI）流程；最终结果还会与 handler 配置里的 `chainToAgent` 做合并，只要任一方为 `true` 就会继续。
+- `audit.tags`：可选，审计标签数组。
+- `error`：可选，错误信息。
+
+### 示例 1：直接回复并终止默认流程
+
+```json
+{
+  "ok": true,
+  "action": "reply_text",
+  "reply": { "text": "已收到 MENU_HELP" },
+  "chainToAgent": false
+}
+```
+
+### 示例 2：不回复，继续默认流程
+
+```json
+{
+  "ok": true,
+  "action": "none",
+  "chainToAgent": true
+}
+```
+
+### `chainToAgent` 补充说明
+
+- 这里的 `chainToAgent` 只代表脚本返回的动态结果，不是唯一决策来源。
+- 如果路由 handler 中也配置了 `"chainToAgent": true`，那么即使脚本返回 `false`，最终仍会继续进入默认 Agent 流程。
+- 如果要让脚本完全决定是否继续，handler 里不要写 `chainToAgent`。
+
+### 示例 3：失败回包（可选）
+
+```json
+{
+  "ok": false,
+  "action": "reply_text",
+  "reply": { "text": "处理失败，请稍后重试" },
+  "chainToAgent": false,
+  "error": "invalid params"
+}
+```
+
+## 注意事项
+
+- 输出必须是严格 JSON。
+- 不要在 `stdout` 混入调试日志；调试信息请写到 `stderr`。
+- 非 0 退出码或非法 JSON 会被视为 handler 执行失败。
+- 脚本路径必须落在 `scriptRuntime.allowPaths` 允许目录内。
+- 脚本应尽量快速返回，避免触发超时（由 `timeoutMs/defaultTimeoutMs` 控制）。

--- a/scripts/wecom/menu-click-help.js
+++ b/scripts/wecom/menu-click-help.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+// 从 stdin 读取平台注入的事件 envelope（JSON）
+let raw = "";
+process.stdin.setEncoding("utf8");
+
+process.stdin.on("data", (chunk) => {
+  raw += chunk;
+});
+
+process.stdin.on("end", () => {
+  let payload = {};
+  try {
+    payload = JSON.parse(raw || "{}");
+  } catch {
+    // 输入异常时返回可读错误，避免脚本抛异常导致无输出
+    process.stdout.write(
+      JSON.stringify({
+        ok: false,
+        action: "reply_text",
+        reply: {
+          text: "事件脚本解析输入失败，请联系管理员。",
+        },
+        chainToAgent: true,
+      }),
+    );
+    return;
+  }
+
+  const message = payload && typeof payload === "object" ? payload.message ?? {} : {};
+  const eventType = String(message.eventType ?? "unknown");
+  const eventKey = String(message.eventKey ?? "");
+  const fromUser = String(message.fromUser ?? "");
+
+  // 这里给出联调用的回显文本，业务可改为真正逻辑
+  const text = [
+    "已收到菜单事件",
+    `eventType=${eventType}`,
+    eventKey ? `eventKey=${eventKey}` : "eventKey=<empty>",
+    fromUser ? `fromUser=${fromUser}` : "",
+    "\n你可以在 openclaw 配置里把这个 eventKey 路由到具体业务脚本。",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  process.stdout.write(
+    JSON.stringify({
+      ok: true,
+      action: "reply_text",
+      reply: {
+        text,
+      },
+      chainToAgent: false,
+      audit: {
+        tags: ["menu", "click", eventType],
+      },
+    }),
+  );
+});

--- a/scripts/wecom/menu-click-help.py
+++ b/scripts/wecom/menu-click-help.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import json
+import sys
+
+
+def main() -> int:
+    # 从 stdin 读取平台注入的事件 envelope（JSON）
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        # 输入异常时返回可读错误，避免脚本抛异常导致无输出
+        json.dump(
+            {
+                "ok": False,
+                "action": "reply_text",
+                "reply": {"text": "事件脚本解析输入失败，请联系管理员。"},
+                "chainToAgent": True,
+            },
+            sys.stdout,
+            ensure_ascii=False,
+        )
+        return 0
+
+    message = payload.get("message", {}) if isinstance(payload, dict) else {}
+    event_type = str(message.get("eventType") or "unknown")
+    event_key = str(message.get("eventKey") or "")
+    from_user = str(message.get("fromUser") or "")
+
+    # 这里给出联调用的回显文本，业务可改为真正逻辑
+    lines = [
+        "已收到菜单事件",
+        f"eventType={event_type}",
+        f"eventKey={event_key or '<empty>'}",
+    ]
+    if from_user:
+        lines.append(f"fromUser={from_user}")
+    lines.append("")
+    lines.append("你可以在 openclaw 配置里把这个 eventKey 路由到具体业务脚本。")
+
+    json.dump(
+        {
+            "ok": True,
+            "action": "reply_text",
+            "reply": {"text": "\n".join(lines)},
+            "chainToAgent": False,
+            "audit": {"tags": ["menu", "click", event_type]},
+        },
+        sys.stdout,
+        ensure_ascii=False,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/event-router.test.ts
+++ b/src/agent/event-router.test.ts
@@ -1,0 +1,421 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { routeAgentInboundEvent } from "./event-router.js";
+import type { ResolvedAgentAccount, WecomAgentInboundMessage } from "../types/index.js";
+import type { WecomRuntimeAuditEvent } from "../types/runtime-context.js";
+
+function createAgent(overrides?: Partial<ResolvedAgentAccount>): ResolvedAgentAccount {
+  return {
+    accountId: "default",
+    configured: true,
+    callbackConfigured: true,
+    apiConfigured: true,
+    corpId: "corp-1",
+    corpSecret: "secret",
+    agentId: 1001,
+    token: "token",
+    encodingAESKey: "aes",
+    eventEnabled: true,
+    allowedEventTypes: ["click", "change_contact"],
+    config: {
+      corpId: "corp-1",
+      corpSecret: "secret",
+      agentId: 1001,
+      token: "token",
+      encodingAESKey: "aes",
+    },
+    ...overrides,
+  };
+}
+
+describe("routeAgentInboundEvent", () => {
+  it("ignores unmatched events when unmatchedAction is ignore", async () => {
+    const agent = createAgent({
+      config: {
+        corpId: "corp-1",
+        corpSecret: "secret",
+        agentId: 1001,
+        token: "token",
+        encodingAESKey: "aes",
+        eventRouting: {
+          unmatchedAction: "ignore",
+          routes: [],
+        },
+      },
+    });
+
+    const result = await routeAgentInboundEvent({
+      agent,
+      msgType: "event",
+      eventType: "click",
+      fromUser: "zhangsan",
+      msg: { MsgType: "event", Event: "click", EventKey: "MENU_X" },
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.chainToAgent).toBe(false);
+    expect(result.reason).toBe("unmatched_event_ignored");
+  });
+
+  it("proxies unmatched events to agent when unmatchedAction is forwardToAgent", async () => {
+    const agent = createAgent({
+      config: {
+        corpId: "corp-1",
+        corpSecret: "secret",
+        agentId: 1001,
+        token: "token",
+        encodingAESKey: "aes",
+        eventRouting: {
+          unmatchedAction: "forwardToAgent",
+          routes: [],
+        },
+      },
+    });
+
+    const result = await routeAgentInboundEvent({
+      agent,
+      msgType: "event",
+      eventType: "click",
+      fromUser: "zhangsan",
+      msg: { MsgType: "event", Event: "click", EventKey: "MENU_X" },
+    });
+
+    expect(result.handled).toBe(false);
+    expect(result.chainToAgent).toBe(true);
+  });
+
+  it("matches builtin echo routes using eventKey", async () => {
+    const agent = createAgent({
+      config: {
+        corpId: "corp-1",
+        corpSecret: "secret",
+        agentId: 1001,
+        token: "token",
+        encodingAESKey: "aes",
+        eventRouting: {
+          routes: [
+            {
+              id: "menu-help",
+              when: { eventType: "click", eventKey: "MENU_HELP" },
+              handler: { type: "builtin", name: "echo" },
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await routeAgentInboundEvent({
+      agent,
+      msgType: "event",
+      eventType: "click",
+      fromUser: "zhangsan",
+      msg: { MsgType: "event", Event: "click", EventKey: "MENU_HELP" },
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.replyText).toContain("event=click");
+    expect(result.replyText).toContain("eventKey=MENU_HELP");
+    expect(result.matchedRouteId).toBe("menu-help");
+  });
+
+  it("matches change_contact routes using changeType", async () => {
+    const agent = createAgent({
+      config: {
+        corpId: "corp-1",
+        corpSecret: "secret",
+        agentId: 1001,
+        token: "token",
+        encodingAESKey: "aes",
+        eventRouting: {
+          routes: [
+            {
+              id: "contact-create-user",
+              when: { eventType: "change_contact", changeType: "create_user" },
+              handler: { type: "builtin", name: "echo" },
+            },
+          ],
+        },
+      },
+    });
+
+    const msg: WecomAgentInboundMessage = {
+      MsgType: "event",
+      Event: "change_contact",
+      ChangeType: "create_user",
+    };
+    const result = await routeAgentInboundEvent({
+      agent,
+      msgType: "event",
+      eventType: "change_contact",
+      fromUser: "sys",
+      msg,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.replyText).toContain("changeType=create_user");
+  });
+
+  it("passes full event params to node scripts", async () => {
+    const fixturePath = path.resolve("src/agent/test-fixtures/reply-event-script.mjs");
+    const agent = createAgent({
+      config: {
+        corpId: "corp-1",
+        corpSecret: "secret",
+        agentId: 1001,
+        token: "token",
+        encodingAESKey: "aes",
+        eventRouting: {
+          routes: [
+            {
+              id: "script-click",
+              when: { eventType: "click", eventKeyPrefix: "MENU_" },
+              handler: { type: "node_script", entry: fixturePath },
+            },
+          ],
+        },
+        scriptRuntime: {
+          enabled: true,
+          allowPaths: [path.resolve("src/agent/test-fixtures")],
+          nodeCommand: process.execPath,
+        },
+      },
+    });
+
+    const result = await routeAgentInboundEvent({
+      agent,
+      msgType: "event",
+      eventType: "click",
+      fromUser: "zhangsan",
+      msg: {
+        ToUserName: "corp-1",
+        FromUserName: "zhangsan",
+        MsgType: "event",
+        Event: "click",
+        EventKey: "MENU_HELP",
+        AgentID: 1001,
+      },
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.replyText).toBe("script:click:MENU_HELP:");
+  });
+
+  it("supports scripts that explicitly continue the default pipeline", async () => {
+    const fixturePath = path.resolve("src/agent/test-fixtures/reply-event-script.mjs");
+    const agent = createAgent({
+      config: {
+        corpId: "corp-1",
+        corpSecret: "secret",
+        agentId: 1001,
+        token: "token",
+        encodingAESKey: "aes",
+        eventRouting: {
+          routes: [
+            {
+              id: "script-click-pass",
+              when: { eventType: "click", eventKey: "PASS_TO_DEFAULT" },
+              handler: { type: "node_script", entry: fixturePath },
+            },
+          ],
+        },
+        scriptRuntime: {
+          enabled: true,
+          allowPaths: [path.resolve("src/agent/test-fixtures")],
+          nodeCommand: process.execPath,
+        },
+      },
+    });
+
+    const result = await routeAgentInboundEvent({
+      agent,
+      msgType: "event",
+      eventType: "click",
+      fromUser: "zhangsan",
+      msg: {
+        MsgType: "event",
+        Event: "click",
+        EventKey: "PASS_TO_DEFAULT",
+      },
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.chainToAgent).toBe(true);
+    expect(result.replyText).toBeUndefined();
+  });
+
+  it("passes full event params to python scripts", async () => {
+    const fixturePath = path.resolve("src/agent/test-fixtures/reply-event-script.py");
+    const agent = createAgent({
+      config: {
+        corpId: "corp-1",
+        corpSecret: "secret",
+        agentId: 1001,
+        token: "token",
+        encodingAESKey: "aes",
+        eventRouting: {
+          routes: [
+            {
+              id: "script-python-click",
+              when: { eventType: "click", eventKey: "MENU_PY" },
+              handler: { type: "python_script", entry: fixturePath },
+            },
+          ],
+        },
+        scriptRuntime: {
+          enabled: true,
+          allowPaths: [path.resolve("src/agent/test-fixtures")],
+          pythonCommand: "python3",
+        },
+      },
+    });
+
+    const result = await routeAgentInboundEvent({
+      agent,
+      msgType: "event",
+      eventType: "click",
+      fromUser: "zhangsan",
+      msg: {
+        MsgType: "event",
+        Event: "click",
+        EventKey: "MENU_PY",
+      },
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.replyText).toBe("python:click:MENU_PY:");
+  });
+
+  it("records audit events for successful script execution", async () => {
+    const fixturePath = path.resolve("src/agent/test-fixtures/reply-event-script.mjs");
+    const auditEvents: WecomRuntimeAuditEvent[] = [];
+    const agent = createAgent({
+      config: {
+        corpId: "corp-1",
+        corpSecret: "secret",
+        agentId: 1001,
+        token: "token",
+        encodingAESKey: "aes",
+        eventRouting: {
+          routes: [
+            {
+              id: "script-audit-success",
+              when: { eventType: "click", eventKey: "MENU_AUDIT" },
+              handler: { type: "node_script", entry: fixturePath },
+            },
+          ],
+        },
+        scriptRuntime: {
+          enabled: true,
+          allowPaths: [path.resolve("src/agent/test-fixtures")],
+          nodeCommand: process.execPath,
+        },
+      },
+    });
+
+    await routeAgentInboundEvent({
+      agent,
+      msgType: "event",
+      eventType: "click",
+      fromUser: "zhangsan",
+      msg: {
+        MsgType: "event",
+        Event: "click",
+        EventKey: "MENU_AUDIT",
+      },
+      auditSink: (event) => auditEvents.push(event),
+    });
+
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0]?.category).toBe("inbound");
+    expect(auditEvents[0]?.summary).toContain("event route script ok");
+  });
+
+  it("captures invalid script output as a routed error and audits it", async () => {
+    const fixturePath = path.resolve("src/agent/test-fixtures/invalid-json-script.mjs");
+    const auditEvents: WecomRuntimeAuditEvent[] = [];
+    const agent = createAgent({
+      config: {
+        corpId: "corp-1",
+        corpSecret: "secret",
+        agentId: 1001,
+        token: "token",
+        encodingAESKey: "aes",
+        eventRouting: {
+          routes: [
+            {
+              id: "script-invalid-json",
+              when: { eventType: "click", eventKey: "MENU_BAD_JSON" },
+              handler: { type: "node_script", entry: fixturePath },
+            },
+          ],
+        },
+        scriptRuntime: {
+          enabled: true,
+          allowPaths: [path.resolve("src/agent/test-fixtures")],
+          nodeCommand: process.execPath,
+        },
+      },
+    });
+
+    const result = await routeAgentInboundEvent({
+      agent,
+      msgType: "event",
+      eventType: "click",
+      fromUser: "zhangsan",
+      msg: {
+        MsgType: "event",
+        Event: "click",
+        EventKey: "MENU_BAD_JSON",
+      },
+      auditSink: (event) => auditEvents.push(event),
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.chainToAgent).toBe(false);
+    expect(result.reason).toBe("script_node_script_error");
+    expect(result.error).toContain("not valid JSON");
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0]?.category).toBe("runtime-error");
+  });
+
+  it("treats invalid eventKeyPattern as non-match instead of throwing", async () => {
+    const auditEvents: WecomRuntimeAuditEvent[] = [];
+    const agent = createAgent({
+      config: {
+        corpId: "corp-1",
+        corpSecret: "secret",
+        agentId: 1001,
+        token: "token",
+        encodingAESKey: "aes",
+        eventRouting: {
+          unmatchedAction: "ignore",
+          routes: [
+            {
+              id: "invalid-pattern",
+              when: { eventType: "click", eventKeyPattern: "(*" },
+              handler: { type: "builtin", name: "echo" },
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await routeAgentInboundEvent({
+      agent,
+      msgType: "event",
+      eventType: "click",
+      fromUser: "zhangsan",
+      msg: { MsgType: "event", Event: "click", EventKey: "MENU_X" },
+      auditSink: (event) => auditEvents.push(event),
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.chainToAgent).toBe(false);
+    expect(result.reason).toBe("unmatched_event_ignored");
+    expect(auditEvents).toHaveLength(1);
+    expect(auditEvents[0]?.category).toBe("runtime-error");
+    expect(auditEvents[0]?.summary).toContain("invalid route eventKeyPattern");
+    expect(auditEvents[0]?.error).toContain("routeId=invalid-pattern");
+  });
+});

--- a/src/agent/event-router.ts
+++ b/src/agent/event-router.ts
@@ -1,0 +1,272 @@
+import { extractAgentId, extractMsgId } from "../shared/xml-parser.js";
+import type {
+  ResolvedAgentAccount,
+  WecomAgentEventRouteConfig,
+  WecomAgentInboundMessage,
+} from "../types/index.js";
+import type { WecomRuntimeAuditEvent } from "../types/runtime-context.js";
+import { runAgentEventScript, type AgentEventScriptEnvelope } from "./script-runner.js";
+
+export type AgentInboundEventRouteResult = {
+  handled: boolean;
+  chainToAgent: boolean;
+  replyText?: string;
+  matchedRouteId?: string;
+  reason: string;
+  error?: string;
+};
+
+// 统一比较口径：事件类型按小写处理
+function normalizeLower(value: unknown): string {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+// 事件键值按原大小写保留，仅做首尾清理
+function normalizeText(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function testPatternSafe(params: {
+  pattern: string;
+  value: string;
+  onInvalidPattern?: (errorMessage: string) => void;
+}): boolean {
+  try {
+    return new RegExp(params.pattern).test(params.value);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    params.onInvalidPattern?.(message);
+    // 配置了非法正则时按“不匹配”处理，避免中断 webhook 主流程
+    return false;
+  }
+}
+
+function matchesRoute(params: {
+  route: WecomAgentEventRouteConfig;
+  eventType: string;
+  changeType: string;
+  eventKey: string;
+  onInvalidPattern?: (errorMessage: string) => void;
+}): boolean {
+  // 三层匹配：eventType -> changeType/eventKey（含 prefix/regex）
+  const when = params.route.when ?? {};
+
+  if (when.eventType && normalizeLower(when.eventType) !== params.eventType) return false;
+  if (when.changeType && normalizeLower(when.changeType) !== params.changeType) return false;
+  if (when.eventKey && normalizeText(when.eventKey) !== params.eventKey) return false;
+  if (when.eventKeyPrefix && !params.eventKey.startsWith(normalizeText(when.eventKeyPrefix))) return false;
+  if (when.eventKeyPattern && !testPatternSafe({
+    pattern: when.eventKeyPattern,
+    value: params.eventKey,
+    onInvalidPattern: params.onInvalidPattern,
+  })) return false;
+
+  return true;
+}
+
+function buildScriptEnvelope(params: {
+  accountId: string;
+  msgType: string;
+  eventType: string;
+  eventKey: string;
+  changeType: string;
+  fromUser: string;
+  toUser?: string;
+  chatId?: string;
+  msg: WecomAgentInboundMessage;
+  matchedRuleId: string;
+  handlerType: "node_script" | "python_script";
+}): AgentEventScriptEnvelope {
+  // 透传给外部脚本：标准化字段 + 原始 XML 解析对象 raw
+  const rawAgentId = extractAgentId(params.msg);
+  const numericAgentId = typeof rawAgentId === "number"
+    ? rawAgentId
+    : Number.isFinite(Number(rawAgentId)) ? Number(rawAgentId) : null;
+
+  return {
+    version: "1.0",
+    channel: "wecom",
+    accountId: params.accountId,
+    receivedAt: Date.now(),
+    message: {
+      msgType: params.msgType,
+      eventType: params.eventType,
+      eventKey: params.eventKey || null,
+      changeType: params.changeType || null,
+      fromUser: params.fromUser,
+      toUser: params.toUser ?? null,
+      chatId: params.chatId ?? null,
+      agentId: numericAgentId,
+      createTime: typeof params.msg.CreateTime === "number" ? params.msg.CreateTime : Number.isFinite(Number(params.msg.CreateTime)) ? Number(params.msg.CreateTime) : null,
+      msgId: extractMsgId(params.msg) ?? null,
+      raw: { ...(params.msg as Record<string, unknown>) },
+    },
+    route: {
+      matchedRuleId: params.matchedRuleId,
+      handlerType: params.handlerType,
+    },
+  };
+}
+
+export async function routeAgentInboundEvent(params: {
+  agent: ResolvedAgentAccount;
+  msgType: string;
+  eventType: string;
+  fromUser: string;
+  chatId?: string;
+  msg: WecomAgentInboundMessage;
+  log?: (msg: string) => void;
+  auditSink?: (event: WecomRuntimeAuditEvent) => void;
+}): Promise<AgentInboundEventRouteResult> {
+  if (normalizeLower(params.msgType) !== "event") {
+    return {
+      handled: false,
+      chainToAgent: false,
+      reason: "not_event",
+    };
+  }
+
+  const routing = params.agent.config.eventRouting;
+  const routes = routing?.routes ?? [];
+  const changeType = normalizeLower(params.msg.ChangeType);
+  const eventKey = normalizeText(params.msg.EventKey);
+  // 路由采用“首个命中即执行”策略
+  const matchedRoute = routes.find((route) => matchesRoute({
+    route,
+    eventType: params.eventType,
+    changeType,
+    eventKey,
+    onInvalidPattern: (errorMessage) => {
+      const routeId = route.id?.trim() || "anonymous";
+      params.log?.(
+        `[wecom-agent] invalid eventKeyPattern in route routeId=${routeId} pattern=${route.when?.eventKeyPattern ?? ""} error=${errorMessage}`,
+      );
+      params.auditSink?.({
+        transport: "agent-callback",
+        category: "runtime-error",
+        messageId: extractMsgId(params.msg) ?? undefined,
+        summary: `invalid route eventKeyPattern routeId=${routeId}`,
+        raw: {
+          transport: "agent-callback",
+          envelopeType: "xml",
+          body: params.msg,
+        },
+        error: `routeId=${routeId} pattern=${route.when?.eventKeyPattern ?? ""} error=${errorMessage}`,
+      });
+    },
+  }));
+
+  if (!matchedRoute) {
+    // 未命中时由 unmatchedAction 决定：忽略 or 继续默认 AI 流程
+    if (routing?.unmatchedAction === "forwardToAgent") {
+      return {
+        handled: false,
+        chainToAgent: true,
+        reason: "unmatched_event_forwardToAgent",
+      };
+    }
+    return {
+      handled: true,
+      chainToAgent: false,
+      reason: "unmatched_event_ignored",
+    };
+  }
+
+  const matchedRouteId = matchedRoute.id?.trim() || `${params.eventType || "event"}:${eventKey || "default"}`;
+  params.log?.(`[wecom-agent] event route matched routeId=${matchedRouteId} event=${params.eventType} eventKey=${eventKey || "N/A"}`);
+
+  if (matchedRoute.handler.type === "builtin") {
+    // 内置 handler：当前仅实现 echo，用于联调和最小可用场景
+    if ((matchedRoute.handler.name ?? "echo") === "echo") {
+      const replyText = [`event=${params.eventType}`,
+        eventKey ? `eventKey=${eventKey}` : "",
+        changeType ? `changeType=${changeType}` : "",
+      ].filter(Boolean).join(" ");
+      return {
+        handled: true,
+        chainToAgent: matchedRoute.handler.chainToAgent === true,
+        replyText,
+        matchedRouteId,
+        reason: "builtin_echo",
+      };
+    }
+  }
+
+  if (matchedRoute.handler.type !== "node_script" && matchedRoute.handler.type !== "python_script") {
+    return {
+      handled: true,
+      chainToAgent: false,
+      matchedRouteId,
+      reason: "unsupported_handler",
+    };
+  }
+
+  try {
+    // 外部脚本 handler：通过 stdin 输入 envelope，stdout 返回 JSON 协议
+    const { response: scriptResponse, meta } = await runAgentEventScript({
+      runtime: params.agent.config.scriptRuntime,
+      handler: matchedRoute.handler,
+      envelope: buildScriptEnvelope({
+        accountId: params.agent.accountId,
+        msgType: params.msgType,
+        eventType: params.eventType,
+        eventKey,
+        changeType,
+        fromUser: params.fromUser,
+        toUser: typeof params.msg.ToUserName === "string" ? params.msg.ToUserName : undefined,
+        chatId: params.chatId,
+        msg: params.msg,
+        matchedRuleId: matchedRouteId,
+        handlerType: matchedRoute.handler.type,
+      }),
+    });
+
+    params.auditSink?.({
+      transport: "agent-callback",
+      category: "inbound",
+      messageId: extractMsgId(params.msg) ?? undefined,
+      summary:
+        `event route script ok routeId=${matchedRouteId} handler=${matchedRoute.handler.type} ` +
+        `event=${params.eventType} durationMs=${meta.durationMs} exitCode=${meta.exitCode ?? "null"}`,
+      raw: {
+        transport: "agent-callback",
+        envelopeType: "xml",
+        body: params.msg,
+      },
+    });
+
+    return {
+      handled: true,
+      chainToAgent:
+        scriptResponse.chainToAgent === true || matchedRoute.handler.chainToAgent === true,
+      replyText: scriptResponse.action === "reply_text" ? scriptResponse.reply?.text : undefined,
+      matchedRouteId,
+      reason: `script_${matchedRoute.handler.type}`,
+    };
+  } catch (err) {
+    // 脚本失败时不抛出到上层，转为“已处理 + 审计错误”，避免中断 webhook 主流程
+    const message = err instanceof Error ? err.message : String(err);
+    params.log?.(
+      `[wecom-agent] event route script failed routeId=${matchedRouteId} handler=${matchedRoute.handler.type} error=${message}`,
+    );
+    params.auditSink?.({
+      transport: "agent-callback",
+      category: "runtime-error",
+      messageId: extractMsgId(params.msg) ?? undefined,
+      summary: `event route script failed routeId=${matchedRouteId} handler=${matchedRoute.handler.type} event=${params.eventType}`,
+      raw: {
+        transport: "agent-callback",
+        envelopeType: "xml",
+        body: params.msg,
+      },
+      error: message,
+    });
+    return {
+      handled: true,
+      chainToAgent: false,
+      matchedRouteId,
+      reason: `script_${matchedRoute.handler.type}_error`,
+      error: message,
+    };
+  }
+}

--- a/src/agent/handler.event-filter.test.ts
+++ b/src/agent/handler.event-filter.test.ts
@@ -31,6 +31,41 @@ describe("shouldProcessAgentInboundMessage", () => {
         expect(unknown.reason).toBe("event:some_random_event");
     });
 
+    it("blocks event processing when eventEnabled is false", () => {
+        const disabled = shouldProcessAgentInboundMessage({
+            msgType: "event",
+            eventType: "click",
+            fromUser: "zhangsan",
+            eventEnabled: false,
+        });
+        expect(disabled.shouldProcess).toBe(false);
+        expect(disabled.reason).toBe("event_disabled");
+    });
+
+    it("allows configured custom event types", () => {
+        const custom = shouldProcessAgentInboundMessage({
+            msgType: "event",
+            eventType: "click",
+            fromUser: "zhangsan",
+            eventEnabled: true,
+            allowedEventTypes: ["click"],
+        });
+        expect(custom.shouldProcess).toBe(true);
+        expect(custom.reason).toBe("allowed_event:click");
+    });
+
+    it("normalizes configured event type values before matching", () => {
+        const custom = shouldProcessAgentInboundMessage({
+            msgType: "event",
+            eventType: "view_miniprogram",
+            fromUser: "zhangsan",
+            eventEnabled: true,
+            allowedEventTypes: [" VIEW_MINIPROGRAM "],
+        });
+        expect(custom.shouldProcess).toBe(true);
+        expect(custom.reason).toBe("allowed_event:view_miniprogram");
+    });
+
     it("skips system sender callbacks", () => {
         const systemSender = shouldProcessAgentInboundMessage({
             msgType: "text",

--- a/src/agent/handler.ts
+++ b/src/agent/handler.ts
@@ -33,6 +33,7 @@ import {
   extractAgentId,
   extractToUser,
 } from "../shared/xml-parser.js";
+import { routeAgentInboundEvent } from "./event-router.js";
 import { resolveOutboundMediaAsset } from "../shared/media-asset.js";
 import {
   downloadAgentApiMedia,
@@ -192,6 +193,8 @@ export function shouldProcessAgentInboundMessage(params: {
   fromUser: string;
   chatId?: string;
   eventType?: string;
+  eventEnabled?: boolean;
+  allowedEventTypes?: string[];
 }): AgentInboundProcessDecision {
   const msgType = String(params.msgType ?? "")
     .trim()
@@ -204,7 +207,8 @@ export function shouldProcessAgentInboundMessage(params: {
     .toLowerCase();
 
   if (msgType === "event") {
-    const allowedEvents = [
+    // 兼容旧行为：未配置 event 策略时，继续沿用历史白名单
+    const compatibilityAllowedEvents = [
       "subscribe",
       "enter_agent",
       "batch_job_result",
@@ -220,6 +224,26 @@ export function shouldProcessAgentInboundMessage(params: {
       "smartsheet_field_change",
       "smartsheet_view_change",
     ];
+    const configuredAllowedEvents = Array.isArray(params.allowedEventTypes)
+      ? params.allowedEventTypes
+          .map((entry) => String(entry ?? "").trim().toLowerCase())
+          .filter(Boolean)
+      : [];
+    const hasEventConfig = params.eventEnabled !== undefined || configuredAllowedEvents.length > 0;
+
+    // 显式关闭 event 时直接拒绝，优先级最高
+    if (params.eventEnabled === false) {
+      return {
+        shouldProcess: false,
+        reason: "event_disabled",
+      };
+    }
+
+    // 配置存在时：历史白名单 + 配置白名单并集，保证平滑迁移
+    const allowedEvents = hasEventConfig
+      ? Array.from(new Set([...compatibilityAllowedEvents, ...configuredAllowedEvents]))
+      : compatibilityAllowedEvents;
+
     if (
       allowedEvents.includes(eventType) ||
       eventType.startsWith("doc_") ||
@@ -276,6 +300,72 @@ function normalizeAgentId(value: unknown): number | undefined {
   if (!raw) return undefined;
   const parsed = Number(raw);
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function resolveAgentReplyTransportContext(params: {
+  agent: ResolvedAgentAccount;
+  msg: WecomAgentInboundMessage;
+  fromUser: string;
+  chatId?: string;
+  log?: (msg: string) => void;
+  error?: (msg: string) => void;
+}): {
+  upstreamAgent?: ResolvedAgentAccount;
+  primaryAgentForUpstream?: ResolvedAgentAccount;
+  upstreamReplyTarget?: { toUser: string | undefined; chatId: string | undefined };
+  effectiveReplyTarget: { toUser: string | undefined; chatId: string | undefined };
+} {
+  // 事件路由也可能需要即时回包，这里复用普通消息的上下游目标判定逻辑
+  const { agent, msg, fromUser, chatId, log, error } = params;
+  const isGroup = Boolean(chatId);
+  const peerId = isGroup ? chatId! : fromUser;
+  const replyTarget = isGroup
+    ? ({ toUser: undefined, chatId: peerId } as const)
+    : ({ toUser: fromUser, chatId: undefined } as const);
+  const toUserName = extractToUser(msg);
+  const isUpstreamUser = detectUpstreamUser({
+    messageToUserName: toUserName,
+    primaryCorpId: agent.corpId,
+  });
+
+  if (!isUpstreamUser) {
+    return {
+      upstreamAgent: undefined,
+      primaryAgentForUpstream: undefined,
+      upstreamReplyTarget: undefined,
+      effectiveReplyTarget: replyTarget,
+    };
+  }
+
+  log?.(`[wecom-agent] detected upstream user during event routing: from=${fromUser} toCorpId=${toUserName}`);
+  const upstreamConfig = resolveUpstreamCorpConfig({
+    upstreamCorpId: toUserName,
+    upstreamCorps: agent.config.upstreamCorps,
+  });
+  if (!upstreamConfig) {
+    error?.(
+      `[wecom-agent] upstream event detected but no upstream config for corpId=${toUserName}; fallback to primary agent target`,
+    );
+    return {
+      upstreamAgent: undefined,
+      primaryAgentForUpstream: undefined,
+      upstreamReplyTarget: undefined,
+      effectiveReplyTarget: replyTarget,
+    };
+  }
+
+  const upstreamAgent = createUpstreamAgentConfig({
+    baseAgent: agent,
+    upstreamCorpId: toUserName,
+    upstreamAgentId: upstreamConfig.agentId,
+  });
+
+  return {
+    upstreamAgent,
+    primaryAgentForUpstream: agent,
+    upstreamReplyTarget: replyTarget,
+    effectiveReplyTarget: replyTarget,
+  };
 }
 
 /**
@@ -391,10 +481,63 @@ async function handleMessageCallback(params: AgentWebhookParams): Promise<boolea
       fromUser,
       chatId,
       eventType,
+      eventEnabled: agent.eventEnabled,
+      allowedEventTypes: agent.allowedEventTypes,
     });
     if (!decision.shouldProcess) {
       log?.(
         `[wecom-agent] skip processing: type=${msgType || "unknown"} event=${eventType || "N/A"} from=${fromUser || "N/A"} reason=${decision.reason}`,
+      );
+      return true;
+    }
+
+    const routedEvent = await routeAgentInboundEvent({
+      agent,
+      msgType,
+      eventType,
+      fromUser,
+      chatId,
+      msg,
+      log,
+      auditSink,
+    });
+    // 路由器返回文本时，先即时回包给用户/群，再决定是否进入默认 AI 流程
+    if (routedEvent.handled && routedEvent.replyText?.trim()) {
+      const replyContext = resolveAgentReplyTransportContext({
+        agent,
+        msg,
+        fromUser,
+        chatId,
+        log,
+        error,
+      });
+      try {
+        if (replyContext.upstreamAgent && replyContext.primaryAgentForUpstream) {
+          await sendUpstreamAgentApiText({
+            upstreamAgent: replyContext.upstreamAgent,
+            primaryAgent: replyContext.primaryAgentForUpstream,
+            ...(replyContext.upstreamReplyTarget ?? replyContext.effectiveReplyTarget),
+            text: routedEvent.replyText,
+          });
+        } else {
+          await sendAgentApiText({
+            agent,
+            ...replyContext.effectiveReplyTarget,
+            text: routedEvent.replyText,
+          });
+        }
+        params.touchTransportSession?.({ lastOutboundAt: Date.now(), running: true });
+        log?.(
+          `[wecom-agent] event route reply delivered routeId=${routedEvent.matchedRouteId ?? "N/A"} to=${chatId ? `chat:${chatId}` : fromUser}`,
+        );
+      } catch (err) {
+        error?.(`[wecom-agent] event route reply failed: ${String(err)}`);
+      }
+    }
+    // routedEvent 已完全消费该事件时，终止后续默认处理链
+    if (routedEvent.handled && !routedEvent.chainToAgent) {
+      log?.(
+        `[wecom-agent] event route handled routeId=${routedEvent.matchedRouteId ?? "N/A"} reason=${routedEvent.reason}`,
       );
       return true;
     }
@@ -420,9 +563,11 @@ async function handleMessageCallback(params: AgentWebhookParams): Promise<boolea
     return true;
   } catch (err) {
     error?.(`[wecom-agent] callback failed: ${String(err)}`);
-    res.statusCode = 400;
-    res.setHeader("Content-Type", "text/plain; charset=utf-8");
-    res.end(`error - 回调处理失败${ERROR_HELP}`);
+    if (!res.headersSent && !res.writableEnded) {
+      res.statusCode = 400;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end(`error - 回调处理失败${ERROR_HELP}`);
+    }
     return true;
   }
 }

--- a/src/agent/script-runner.ts
+++ b/src/agent/script-runner.ts
@@ -1,0 +1,186 @@
+import path from "node:path";
+import { spawn } from "node:child_process";
+
+import type {
+  WecomAgentEventRouteHandlerConfig,
+  WecomAgentScriptRuntimeConfig,
+} from "../types/index.js";
+
+export type AgentEventScriptEnvelope = {
+  version: "1.0";
+  channel: "wecom";
+  accountId: string;
+  receivedAt: number;
+  message: {
+    msgType: string;
+    eventType: string;
+    eventKey: string | null;
+    changeType: string | null;
+    fromUser: string;
+    toUser: string | null;
+    chatId: string | null;
+    agentId: number | null;
+    createTime: number | null;
+    msgId: string | null;
+    raw: Record<string, unknown>;
+  };
+  route: {
+    matchedRuleId: string;
+    handlerType: "node_script" | "python_script";
+  };
+};
+
+export type AgentEventScriptResponse = {
+  ok?: boolean;
+  action?: "none" | "reply_text";
+  reply?: {
+    text?: string;
+  };
+  chainToAgent?: boolean;
+  audit?: {
+    tags?: string[];
+  };
+  error?: string;
+};
+
+export type AgentEventScriptExecutionMeta = {
+  command: string;
+  entryPath: string;
+  durationMs: number;
+  exitCode: number | null;
+};
+
+function resolveAllowedRoots(runtime: WecomAgentScriptRuntimeConfig): string[] {
+  return (runtime.allowPaths ?? []).map((entry) => path.resolve(entry));
+}
+
+function resolveScriptEntry(entry: string): string {
+  return path.resolve(entry);
+}
+
+function ensureScriptAllowed(entryPath: string, runtime: WecomAgentScriptRuntimeConfig): void {
+  // 安全兜底：脚本执行必须显式开启
+  if (runtime.enabled !== true) {
+    throw new Error("script runtime is disabled");
+  }
+  // 安全兜底：必须配置允许目录，拒绝任意路径执行
+  const roots = resolveAllowedRoots(runtime);
+  if (roots.length === 0) {
+    throw new Error("script runtime allowPaths is empty");
+  }
+  const allowed = roots.some((root) => entryPath === root || entryPath.startsWith(`${root}${path.sep}`));
+  if (!allowed) {
+    throw new Error(`script path is not allowed: ${entryPath}`);
+  }
+}
+
+export async function runAgentEventScript(params: {
+  runtime: WecomAgentScriptRuntimeConfig | undefined;
+  handler: Extract<WecomAgentEventRouteHandlerConfig, { type: "node_script" | "python_script" }>;
+  envelope: AgentEventScriptEnvelope;
+}): Promise<{ response: AgentEventScriptResponse; meta: AgentEventScriptExecutionMeta }> {
+  const runtime = params.runtime ?? {};
+  const entryPath = resolveScriptEntry(params.handler.entry);
+  ensureScriptAllowed(entryPath, runtime);
+
+  // 优先使用 route 覆盖值，其次使用全局 runtime 默认值
+  const timeoutMs = params.handler.timeoutMs ?? runtime.defaultTimeoutMs ?? 5000;
+  const maxStdoutBytes = runtime.maxStdoutBytes ?? 262144;
+  const maxStderrBytes = runtime.maxStderrBytes ?? 131072;
+  const command = params.handler.type === "python_script"
+    ? runtime.pythonCommand ?? "python3"
+    : runtime.nodeCommand ?? "node";
+  const startedAt = Date.now();
+
+  return await new Promise<{ response: AgentEventScriptResponse; meta: AgentEventScriptExecutionMeta }>((resolve, reject) => {
+    const child = spawn(command, [entryPath], {
+      cwd: process.cwd(),
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        PATH: process.env.PATH ?? "",
+      },
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let stdoutExceeded = false;
+    let stderrExceeded = false;
+    let settled = false;
+    let exitCode: number | null = null;
+
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    };
+
+    const timer = setTimeout(() => {
+      // 超时强制终止，防止脚本阻塞事件处理链
+      child.kill("SIGKILL");
+      finish(() => reject(new Error(`script execution timed out after ${timeoutMs}ms`)));
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      const value = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      // 限制输出体积，避免异常脚本刷爆内存/日志
+      if (Buffer.byteLength(stdout, "utf8") + Buffer.byteLength(value, "utf8") > maxStdoutBytes) {
+        stdoutExceeded = true;
+        return;
+      }
+      stdout += value;
+    });
+
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      const value = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      if (Buffer.byteLength(stderr, "utf8") + Buffer.byteLength(value, "utf8") > maxStderrBytes) {
+        stderrExceeded = true;
+        return;
+      }
+      stderr += value;
+    });
+
+    child.on("error", (err) => {
+      finish(() => reject(err));
+    });
+
+    child.on("close", (code) => {
+      exitCode = code;
+      const meta: AgentEventScriptExecutionMeta = {
+        command,
+        entryPath,
+        durationMs: Date.now() - startedAt,
+        exitCode,
+      };
+      if (stdoutExceeded) {
+        finish(() => reject(new Error("script stdout exceeded limit")));
+        return;
+      }
+      if (stderrExceeded) {
+        finish(() => reject(new Error("script stderr exceeded limit")));
+        return;
+      }
+      if (code !== 0) {
+        finish(() => reject(new Error(`script exited with code ${code}: ${stderr.trim() || stdout.trim()}`)));
+        return;
+      }
+      const trimmed = stdout.trim();
+      if (!trimmed) {
+        // 空输出按无动作处理，减少脚本端样板代码
+        finish(() => resolve({ response: { ok: true, action: "none" }, meta }));
+        return;
+      }
+      try {
+        // 脚本协议要求 stdout 必须是 JSON
+        const parsed = JSON.parse(trimmed) as AgentEventScriptResponse;
+        finish(() => resolve({ response: parsed, meta }));
+      } catch (err) {
+        finish(() => reject(new Error(`script output is not valid JSON: ${String(err)}`)));
+      }
+    });
+
+    // 将完整 envelope 传给脚本，再关闭 stdin
+    child.stdin.write(JSON.stringify(params.envelope));
+    child.stdin.end();
+  });
+}

--- a/src/agent/test-fixtures/invalid-json-script.mjs
+++ b/src/agent/test-fixtures/invalid-json-script.mjs
@@ -1,0 +1,1 @@
+process.stdout.write("this is not json");

--- a/src/agent/test-fixtures/reply-event-script.mjs
+++ b/src/agent/test-fixtures/reply-event-script.mjs
@@ -1,0 +1,29 @@
+let raw = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  raw += chunk;
+});
+process.stdin.on("end", () => {
+  const payload = JSON.parse(raw || "{}");
+  const eventType = payload?.message?.eventType ?? "unknown";
+  const eventKey = payload?.message?.eventKey ?? "";
+  const changeType = payload?.message?.changeType ?? "";
+
+  if (eventKey === "PASS_TO_DEFAULT") {
+    process.stdout.write(JSON.stringify({
+      ok: true,
+      action: "none",
+      chainToAgent: true,
+    }));
+    return;
+  }
+
+  process.stdout.write(JSON.stringify({
+    ok: true,
+    action: "reply_text",
+    reply: {
+      text: `script:${eventType}:${eventKey}:${changeType}`,
+    },
+    chainToAgent: false,
+  }));
+});

--- a/src/agent/test-fixtures/reply-event-script.py
+++ b/src/agent/test-fixtures/reply-event-script.py
@@ -1,0 +1,17 @@
+import json
+import sys
+
+payload = json.load(sys.stdin)
+message = payload.get("message", {})
+event_type = message.get("eventType", "unknown")
+event_key = message.get("eventKey") or ""
+change_type = message.get("changeType") or ""
+
+json.dump({
+    "ok": True,
+    "action": "reply_text",
+    "reply": {
+        "text": f"python:{event_type}:{event_key}:{change_type}"
+    },
+    "chainToAgent": False
+}, sys.stdout)

--- a/src/channel.config.test.ts
+++ b/src/channel.config.test.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { describe, expect, it } from "vitest";
 
 import { wecomPlugin } from "./channel.js";
+import { resolveWecomAccounts } from "./config/accounts.js";
 
 describe("wecomPlugin config.deleteAccount", () => {
   it("removes only the target matrix account", () => {
@@ -143,5 +144,37 @@ describe("wecomPlugin account conflict guards", () => {
     expect(wecomPlugin.config.unconfiguredReason?.(accountB, cfg)).toContain(
       "Duplicate WeCom agent identity",
     );
+  });
+
+  it("normalizes agent inbound event policy on resolved accounts", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        wecom: {
+          enabled: true,
+          accounts: {
+            default: {
+              enabled: true,
+              agent: {
+                corpId: "corp-1",
+                corpSecret: "secret-a",
+                agentId: 1001,
+                token: "token-a",
+                encodingAESKey: "aes-a",
+                inboundPolicy: {
+                  eventEnabled: true,
+                  eventPolicy: {
+                    allowedEventTypes: [" Click ", "view", "click"],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const resolved = resolveWecomAccounts(cfg);
+    expect(resolved.accounts.default?.agent?.eventEnabled).toBe(true);
+    expect(resolved.accounts.default?.agent?.allowedEventTypes).toEqual(["click", "view"]);
   });
 });

--- a/src/config/accounts.ts
+++ b/src/config/accounts.ts
@@ -28,6 +28,15 @@ function toNumber(value: number | string | undefined): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function normalizeAllowedEventTypes(value: string[] | undefined): string[] | undefined {
+  // 配置层允许大小写/空白混写，这里统一规整为去重后的小写列表
+  if (!Array.isArray(value)) return undefined;
+  const normalized = value
+    .map((entry) => String(entry ?? "").trim().toLowerCase())
+    .filter(Boolean);
+  return normalized.length > 0 ? Array.from(new Set(normalized)) : undefined;
+}
+
 function resolveBotAccount(
   accountId: string,
   config: WecomBotConfig,
@@ -75,6 +84,11 @@ function resolveAgentAccount(
   const callbackConfigured = Boolean(config.token && config.encodingAESKey);
   const normalizedAgentSecret = config.agentSecret?.trim() || config.corpSecret?.trim() || "";
   const apiConfigured = Boolean(config.corpId && normalizedAgentSecret && agentId);
+  // 将 event 相关策略提前归一到运行态，避免每次消息都重复解析配置
+  const eventEnabled = config.inboundPolicy?.eventEnabled;
+  const allowedEventTypes = normalizeAllowedEventTypes(
+    config.inboundPolicy?.eventPolicy?.allowedEventTypes,
+  );
   return {
     accountId,
     configured: callbackConfigured || apiConfigured,
@@ -85,6 +99,8 @@ function resolveAgentAccount(
     agentId,
     token: config.token,
     encodingAESKey: config.encodingAESKey,
+    eventEnabled,
+    allowedEventTypes,
     config,
     network,
   };

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3,6 +3,61 @@ export interface DmConfig {
   allowFrom?: (string | number)[];
 }
 
+export interface AgentEventPolicyConfig {
+  allowedEventTypes?: string[];
+}
+
+export interface AgentInboundPolicyConfig {
+  eventEnabled?: boolean;
+  eventPolicy?: AgentEventPolicyConfig;
+}
+
+export interface AgentEventRouteMatchConfig {
+  eventType?: string;
+  changeType?: string;
+  eventKey?: string;
+  eventKeyPrefix?: string;
+  eventKeyPattern?: string;
+}
+
+export interface AgentEventRouteHandlerBuiltinConfig {
+  type: "builtin";
+  name?: "echo";
+  chainToAgent?: boolean;
+}
+
+export interface AgentEventRouteHandlerScriptConfig {
+  type: "node_script" | "python_script";
+  entry: string;
+  timeoutMs?: number;
+  chainToAgent?: boolean;
+}
+
+export type AgentEventRouteHandlerConfig =
+  | AgentEventRouteHandlerBuiltinConfig
+  | AgentEventRouteHandlerScriptConfig;
+
+export interface AgentEventRouteConfig {
+  id?: string;
+  when?: AgentEventRouteMatchConfig;
+  handler: AgentEventRouteHandlerConfig;
+}
+
+export interface AgentEventRoutingConfig {
+  unmatchedAction?: "ignore" | "forwardToAgent";
+  routes?: AgentEventRouteConfig[];
+}
+
+export interface AgentScriptRuntimeConfig {
+  enabled?: boolean;
+  allowPaths?: string[];
+  maxStdoutBytes?: number;
+  maxStderrBytes?: number;
+  defaultTimeoutMs?: number;
+  pythonCommand?: string;
+  nodeCommand?: string;
+}
+
 export interface MediaConfig {
   tempDir?: string;
   retentionHours?: number;
@@ -50,6 +105,9 @@ export interface AgentConfig {
   encodingAESKey: string;
   welcomeText?: string;
   dm?: DmConfig;
+  inboundPolicy?: AgentInboundPolicyConfig;
+  eventRouting?: AgentEventRoutingConfig;
+  scriptRuntime?: AgentScriptRuntimeConfig;
 }
 
 export interface DynamicAgentsConfig {

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -47,6 +47,8 @@ export type ResolvedAgentAccount = {
   agentId?: number;
   token: string;
   encodingAESKey: string;
+  eventEnabled?: boolean;
+  allowedEventTypes?: string[];
   config: WecomAgentConfig;
   network?: WecomNetworkConfig;
 };

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -6,6 +6,59 @@ export type WecomDmConfig = {
   allowFrom?: Array<string | number>;
 };
 
+export type WecomAgentEventPolicyConfig = {
+  allowedEventTypes?: string[];
+};
+
+export type WecomAgentInboundPolicyConfig = {
+  eventEnabled?: boolean;
+  eventPolicy?: WecomAgentEventPolicyConfig;
+};
+
+export type WecomAgentEventRouteMatchConfig = {
+  eventType?: string;
+  changeType?: string;
+  eventKey?: string;
+  eventKeyPrefix?: string;
+  eventKeyPattern?: string;
+};
+
+export type WecomAgentEventBuiltinHandlerName = "echo";
+
+export type WecomAgentEventRouteHandlerConfig =
+  | {
+      type: "builtin";
+      name?: WecomAgentEventBuiltinHandlerName;
+      chainToAgent?: boolean;
+    }
+  | {
+      type: "node_script" | "python_script";
+      entry: string;
+      timeoutMs?: number;
+      chainToAgent?: boolean;
+    };
+
+export type WecomAgentEventRouteConfig = {
+  id?: string;
+  when?: WecomAgentEventRouteMatchConfig;
+  handler: WecomAgentEventRouteHandlerConfig;
+};
+
+export type WecomAgentEventRoutingConfig = {
+  unmatchedAction?: "ignore" | "forwardToAgent";
+  routes?: WecomAgentEventRouteConfig[];
+};
+
+export type WecomAgentScriptRuntimeConfig = {
+  enabled?: boolean;
+  allowPaths?: string[];
+  maxStdoutBytes?: number;
+  maxStderrBytes?: number;
+  defaultTimeoutMs?: number;
+  pythonCommand?: string;
+  nodeCommand?: string;
+};
+
 export type WecomMediaConfig = {
   tempDir?: string;
   retentionHours?: number;
@@ -71,6 +124,9 @@ export type WecomAgentConfig = {
   encodingAESKey: string;
   welcomeText?: string;
   dm?: WecomDmConfig;
+  inboundPolicy?: WecomAgentInboundPolicyConfig;
+  eventRouting?: WecomAgentEventRoutingConfig;
+  scriptRuntime?: WecomAgentScriptRuntimeConfig;
   /**
    * 上下游企业配置映射
    * key: 配置名称（可自定义）

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -128,8 +128,10 @@ export type WecomAgentInboundMessage = {
     // 事件消息
     Event?: string;
     EventKey?: string;
+    ChangeType?: string;
     // 群聊
     ChatId?: string;
+    [key: string]: unknown;
 };
 
 /**


### PR DESCRIPTION
本地脚本可以被event click调用，菜单需要让agent自己创建，
可调用本地python或者js脚本，可以选择command路径，可以将调用的返回值再chain回给龙虾继续拿到返回值继续处理
新增event监听解析路由和action的初始版本，未来会持续优化添加卡片交互的状态缓存用来支持更高级的企业应用交互

企业业务中有一些CRM或者ERP应用规范程度很高，每次跟龙虾说半天不如点击一个按钮弹出一个卡片交互填写一些数据

注意：企业微信管理后台目前不支持创建click事件的菜单需要调用接口创建

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configurable menu event routing with event type filtering and allowlisting
  * Support for custom event handlers via Node.js or Python scripts
  * Built-in echo handler for event replies
  * Event processing enable/disable controls

* **Documentation**
  * Menu event configuration guide with routing rules and troubleshooting FAQ
  * Handler script protocol and execution examples
  * Event handler development documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->