### PR TITLE
feat: 添加支持文件图片视频在群聊或私聊可以被引用，引用中的文件能被bot渠道看到

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -11,7 +11,11 @@ export {
 } from "./accounts.js";
 export { resolveWecomRuntimeAccount, resolveWecomRuntimeConfig, type ResolvedRuntimeAccount, type ResolvedRuntimeConfig } from "./runtime-config.js";
 export { resolveDerivedPath, resolveDerivedPathSummary } from "./derived-paths.js";
-export { resolveWecomEgressProxyUrl, resolveWecomEgressProxyUrlFromNetwork } from "./network.js";
+export {
+  resolveWecomEgressProxyUrl,
+  resolveWecomEgressProxyUrlFromNetwork,
+  resolveWecomMediaDownloadTimeoutMs,
+} from "./network.js";
 export {
   DEFAULT_WECOM_MEDIA_MAX_BYTES,
   getWecomDefaultMediaLocalRoots,

--- a/src/config/network.ts
+++ b/src/config/network.ts
@@ -2,6 +2,16 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk";
 
 import type { WecomConfig, WecomNetworkConfig } from "../types/index.js";
 
+const DEFAULT_WECOM_MEDIA_DOWNLOAD_TIMEOUT_MS = 30_000;
+
+function parsePositiveInt(value: unknown): number | undefined {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return undefined;
+  }
+  return Math.floor(parsed);
+}
+
 export function resolveWecomEgressProxyUrlFromNetwork(network?: WecomNetworkConfig): string | undefined {
   const proxyUrl = network?.egressProxyUrl ??
     process.env.OPENCLAW_WECOM_EGRESS_PROXY_URL ??
@@ -17,4 +27,27 @@ export function resolveWecomEgressProxyUrlFromNetwork(network?: WecomNetworkConf
 export function resolveWecomEgressProxyUrl(cfg: OpenClawConfig): string | undefined {
   const wecom = cfg.channels?.wecom as WecomConfig | undefined;
   return resolveWecomEgressProxyUrlFromNetwork(wecom?.network);
+}
+
+export function resolveWecomMediaDownloadTimeoutMs(cfg: OpenClawConfig): number {
+  const wecom = cfg.channels?.wecom as
+    | {
+        media?: { downloadTimeoutMs?: unknown };
+        mediaDownloadTimeoutMs?: unknown;
+        network?: {
+          mediaDownloadTimeoutMs?: unknown;
+          timeoutMs?: unknown;
+        };
+      }
+    | undefined;
+
+  const timeoutMs =
+    parsePositiveInt(wecom?.media?.downloadTimeoutMs) ??
+    parsePositiveInt(wecom?.mediaDownloadTimeoutMs) ??
+    parsePositiveInt(wecom?.network?.mediaDownloadTimeoutMs) ??
+    parsePositiveInt(wecom?.network?.timeoutMs) ??
+    parsePositiveInt(process.env.OPENCLAW_WECOM_MEDIA_TIMEOUT_MS) ??
+    parsePositiveInt(process.env.WECOM_MEDIA_TIMEOUT_MS);
+
+  return timeoutMs ?? DEFAULT_WECOM_MEDIA_DOWNLOAD_TIMEOUT_MS;
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -92,10 +92,18 @@ export async function wecomFetch(input: string | URL, init?: RequestInit, opts?:
     );
     return response;
   } catch (err: unknown) {
-    if (err instanceof Error && err.name === "TypeError" && err.message === "fetch failed") {
+    if (err instanceof Error && err.name === "TimeoutError") {
+      console.error(
+        `[wecom-http] timeout method=${method} target=${target} durationMs=${Date.now() - startedAt} proxy=${proxyUrl || "none"}`,
+      );
+    } else if (err instanceof Error && err.name === "TypeError" && err.message === "fetch failed") {
       const cause = (err as any).cause;
       console.error(
         `[wecom-http] fetch failed method=${method} target=${target} durationMs=${Date.now() - startedAt} proxy=${proxyUrl || "none"}${cause ? ` cause=${String(cause)}` : ""}`,
+      );
+    } else if (err instanceof Error && err.name === "AbortError") {
+      console.error(
+        `[wecom-http] aborted method=${method} target=${target} durationMs=${Date.now() - startedAt} proxy=${proxyUrl || "none"}`,
       );
     }
     throw err;

--- a/src/shared/media-service.ts
+++ b/src/shared/media-service.ts
@@ -1,5 +1,9 @@
 import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk";
-import { resolveWecomMediaMaxBytes } from "../config/index.js";
+import {
+  resolveWecomEgressProxyUrl,
+  resolveWecomMediaDownloadTimeoutMs,
+  resolveWecomMediaMaxBytes,
+} from "../config/index.js";
 import { decryptWecomMediaWithMeta } from "../media.js";
 import type { UnifiedInboundEvent } from "../types/index.js";
 import type { NormalizedMediaAttachment } from "./media-types.js";
@@ -40,8 +44,13 @@ export class WecomMediaService {
     aesKey: string;
     maxBytes: number;
   }): Promise<NormalizedMediaAttachment> {
+    const proxyUrl = resolveWecomEgressProxyUrl(this.cfg);
+    const timeoutMs = resolveWecomMediaDownloadTimeoutMs(this.cfg);
+    const urlHost = (() => { try { return new URL(params.url).hostname; } catch { return "?"; } })();
+    const t0 = Date.now();
     const decrypted = await decryptWecomMediaWithMeta(params.url, params.aesKey, {
       maxBytes: params.maxBytes,
+      http: { proxyUrl, timeoutMs },
     });
     return {
       buffer: decrypted.buffer,

--- a/src/transport/bot-webhook/inbound-normalizer.test.ts
+++ b/src/transport/bot-webhook/inbound-normalizer.test.ts
@@ -1,0 +1,433 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { processBotInboundMessage } from "./inbound-normalizer.js";
+import { decryptWecomMediaWithMeta } from "../../media.js";
+
+vi.mock("../../media.js", () => ({
+  decryptWecomMediaWithMeta: vi.fn(),
+}));
+
+describe("processBotInboundMessage quote media", () => {
+  const recordOperationalIssue = vi.fn();
+  const logError = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("downloads quote.file for text messages", async () => {
+    vi.mocked(decryptWecomMediaWithMeta).mockResolvedValue({
+      buffer: Buffer.from("%PDF-1.7 test"),
+      sourceContentType: "application/pdf",
+      sourceFilename: "quoted.pdf",
+      sourceUrl: "https://example.com/quoted.pdf",
+    });
+
+    const result = await processBotInboundMessage({
+      target: {
+        account: {
+          accountId: "purple",
+          encodingAESKey: "account-aes-key",
+        },
+        config: {
+          channels: {
+            wecom: {
+              mediaMaxMb: 24,
+            },
+          },
+        },
+        runtime: {
+          error: logError,
+        },
+      } as never,
+      msg: {
+        msgid: "msg-quote-file",
+        msgtype: "text",
+        text: { content: "看这个引用" },
+        quote: {
+          msgtype: "file",
+          file: {
+            url: "https://example.com/quoted.pdf",
+          },
+        },
+      } as never,
+      recordOperationalIssue,
+    });
+
+    expect(decryptWecomMediaWithMeta).toHaveBeenCalledWith(
+      "https://example.com/quoted.pdf",
+      "account-aes-key",
+      expect.objectContaining({
+        maxBytes: 24 * 1024 * 1024,
+      }),
+    );
+    expect(result.media).toBeDefined();
+    expect(result.media?.contentType).toBe("application/pdf");
+    expect(result.body).toContain("[引用: 文件]");
+  });
+
+  it("keeps quote.voice as text only without media decryption", async () => {
+    const result = await processBotInboundMessage({
+      target: {
+        account: {
+          accountId: "purple",
+          encodingAESKey: "account-aes-key",
+        },
+        config: {
+          channels: {
+            wecom: {
+              mediaMaxMb: 24,
+            },
+          },
+        },
+        runtime: {
+          error: logError,
+        },
+      } as never,
+      msg: {
+        msgid: "msg-quote-voice",
+        msgtype: "text",
+        text: { content: "这个语音引用是什么意思" },
+        quote: {
+          msgtype: "voice",
+          voice: { content: "这里是语音转写文本" },
+        },
+      } as never,
+      recordOperationalIssue,
+    });
+
+    expect(result.media).toBeUndefined();
+    expect(result.body).toContain("[引用: 语音] 这里是语音转写文本");
+    expect(decryptWecomMediaWithMeta).not.toHaveBeenCalled();
+  });
+
+  it("extracts first image from quote.mixed", async () => {
+    vi.mocked(decryptWecomMediaWithMeta).mockResolvedValue({
+      buffer: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      sourceContentType: "image/png",
+      sourceFilename: "quoted.png",
+      sourceUrl: "https://example.com/quoted.png",
+    });
+
+    const result = await processBotInboundMessage({
+      target: {
+        account: {
+          accountId: "purple",
+          encodingAESKey: "account-aes-key",
+        },
+        config: {
+          channels: {
+            wecom: {
+              mediaMaxMb: 24,
+            },
+          },
+        },
+        runtime: {
+          error: logError,
+        },
+      } as never,
+      msg: {
+        msgid: "msg-quote-mixed",
+        msgtype: "text",
+        text: { content: "看这个图文引用" },
+        quote: {
+          msgtype: "mixed",
+          mixed: {
+            msg_item: [
+              { msgtype: "text", text: { content: "正文" } },
+              { msgtype: "image", image: { url: "https://example.com/quoted.png", aeskey: "item-aes-key" } },
+            ],
+          },
+        },
+      } as never,
+      recordOperationalIssue,
+    });
+
+    expect(result.media).toBeDefined();
+    expect(result.media?.contentType).toBe("image/png");
+    expect(decryptWecomMediaWithMeta).toHaveBeenCalledWith(
+      "https://example.com/quoted.png",
+      "item-aes-key",
+      expect.any(Object),
+    );
+  });
+
+  it("records expired_or_forbidden reason for quote media decrypt failure", async () => {
+    vi.mocked(decryptWecomMediaWithMeta).mockRejectedValue(new Error("HTTP 403 forbidden"));
+
+    const result = await processBotInboundMessage({
+      target: {
+        account: {
+          accountId: "purple",
+          encodingAESKey: "account-aes-key",
+        },
+        config: {
+          channels: {
+            wecom: {
+              mediaMaxMb: 24,
+            },
+          },
+        },
+        runtime: {
+          error: logError,
+        },
+      } as never,
+      msg: {
+        msgid: "msg-quote-fail",
+        msgtype: "text",
+        text: { content: "读取这个引用" },
+        quote: {
+          msgtype: "file",
+          file: { url: "https://example.com/expired.pdf" },
+        },
+      } as never,
+      recordOperationalIssue,
+    });
+
+    expect(result.media).toBeUndefined();
+    expect(result.body).toContain("[quote:file]");
+    expect(recordOperationalIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: expect.stringContaining("reason=expired_or_forbidden"),
+      }),
+    );
+  });
+
+  it("downloads quote.image for text messages", async () => {
+    vi.mocked(decryptWecomMediaWithMeta).mockResolvedValue({
+      buffer: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      sourceContentType: "image/png",
+      sourceFilename: "quoted.png",
+      sourceUrl: "https://example.com/quoted.png",
+    });
+
+    const result = await processBotInboundMessage({
+      target: {
+        account: {
+          accountId: "purple",
+          encodingAESKey: "account-aes-key",
+        },
+        config: {
+          channels: {
+            wecom: {
+              mediaMaxMb: 24,
+            },
+          },
+        },
+        runtime: {
+          error: logError,
+        },
+      } as never,
+      msg: {
+        msgid: "msg-quote-image",
+        msgtype: "text",
+        text: { content: "看这个引用图片" },
+        quote: {
+          msgtype: "image",
+          image: {
+            url: "https://example.com/quoted.png",
+          },
+        },
+      } as never,
+      recordOperationalIssue,
+    });
+
+    expect(decryptWecomMediaWithMeta).toHaveBeenCalledWith(
+      "https://example.com/quoted.png",
+      "account-aes-key",
+      expect.objectContaining({
+        maxBytes: 24 * 1024 * 1024,
+      }),
+    );
+    expect(result.media).toBeDefined();
+    expect(result.media?.contentType).toBe("image/png");
+    expect(result.body).toContain("[引用: 图片]");
+  });
+
+  it("downloads quote.video for text messages", async () => {
+    vi.mocked(decryptWecomMediaWithMeta).mockResolvedValue({
+      buffer: Buffer.from([0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70]),
+      sourceContentType: "video/mp4",
+      sourceFilename: "quoted.mp4",
+      sourceUrl: "https://example.com/quoted.mp4",
+    });
+
+    const result = await processBotInboundMessage({
+      target: {
+        account: {
+          accountId: "purple",
+          encodingAESKey: "account-aes-key",
+        },
+        config: {
+          channels: {
+            wecom: {
+              mediaMaxMb: 24,
+            },
+          },
+        },
+        runtime: {
+          error: logError,
+        },
+      } as never,
+      msg: {
+        msgid: "msg-quote-video",
+        msgtype: "text",
+        text: { content: "看这个引用视频" },
+        quote: {
+          msgtype: "video",
+          video: {
+            url: "https://example.com/quoted.mp4",
+          },
+        },
+      } as never,
+      recordOperationalIssue,
+    });
+
+    expect(decryptWecomMediaWithMeta).toHaveBeenCalledWith(
+      "https://example.com/quoted.mp4",
+      "account-aes-key",
+      expect.objectContaining({
+        maxBytes: 24 * 1024 * 1024,
+      }),
+    );
+    expect(result.media).toBeDefined();
+    expect(result.media?.contentType).toBe("video/mp4");
+    expect(result.body).toContain("[引用: 视频]");
+  });
+
+  it("prioritizes top-level media over quote media", async () => {
+    vi.mocked(decryptWecomMediaWithMeta).mockResolvedValue({
+      buffer: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      sourceContentType: "image/png",
+      sourceFilename: "top-level.png",
+      sourceUrl: "https://example.com/top-level.png",
+    });
+
+    const result = await processBotInboundMessage({
+      target: {
+        account: {
+          accountId: "purple",
+          encodingAESKey: "account-aes-key",
+        },
+        config: {
+          channels: {
+            wecom: {
+              mediaMaxMb: 24,
+            },
+          },
+        },
+        runtime: {
+          error: logError,
+        },
+      } as never,
+      msg: {
+        msgid: "msg-both-media",
+        msgtype: "image",
+        image: {
+          url: "https://example.com/top-level.png",
+        },
+        quote: {
+          msgtype: "file",
+          file: {
+            url: "https://example.com/quoted.pdf",
+          },
+        },
+      } as never,
+      recordOperationalIssue,
+    });
+
+    // Should have downloaded top-level image, not quote file
+    expect(decryptWecomMediaWithMeta).toHaveBeenCalledWith(
+      "https://example.com/top-level.png",
+      "account-aes-key",
+      expect.any(Object),
+    );
+    expect(decryptWecomMediaWithMeta).not.toHaveBeenCalledWith(
+      expect.stringContaining("quoted.pdf"),
+      expect.any(String),
+      expect.any(Object),
+    );
+    expect(result.media?.contentType).toBe("image/png");
+    expect(result.body).toBe("[image]");
+  });
+
+  it("classifies timeout error for quote media", async () => {
+    vi.mocked(decryptWecomMediaWithMeta).mockRejectedValue(new Error("Request timeout after 15000ms"));
+
+    const result = await processBotInboundMessage({
+      target: {
+        account: {
+          accountId: "purple",
+          encodingAESKey: "account-aes-key",
+        },
+        config: {
+          channels: {
+            wecom: {
+              mediaMaxMb: 24,
+            },
+          },
+        },
+        runtime: {
+          error: logError,
+        },
+      } as never,
+      msg: {
+        msgid: "msg-quote-timeout",
+        msgtype: "text",
+        text: { content: "下载这个文件" },
+        quote: {
+          msgtype: "file",
+          file: { url: "https://example.com/slow.pdf" },
+        },
+      } as never,
+      recordOperationalIssue,
+    });
+
+    expect(result.media).toBeUndefined();
+    expect(recordOperationalIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: expect.stringContaining("reason=timeout"),
+      }),
+    );
+  });
+
+  it("classifies decrypt error for quote media", async () => {
+    vi.mocked(decryptWecomMediaWithMeta).mockRejectedValue(new Error("Bad decrypt"));
+
+    const result = await processBotInboundMessage({
+      target: {
+        account: {
+          accountId: "purple",
+          encodingAESKey: "account-aes-key",
+        },
+        config: {
+          channels: {
+            wecom: {
+              mediaMaxMb: 24,
+            },
+          },
+        },
+        runtime: {
+          error: logError,
+        },
+      } as never,
+      msg: {
+        msgid: "msg-quote-decrypt-fail",
+        msgtype: "voice",
+        voice: { content: "这是语音转写" },
+        quote: {
+          msgtype: "image",
+          image: { url: "https://example.com/bad.png" },
+        },
+      } as never,
+      recordOperationalIssue,
+    });
+
+    expect(result.media).toBeUndefined();
+    expect(recordOperationalIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: expect.stringContaining("reason=decrypt"),
+      }),
+    );
+  });
+});

--- a/src/transport/bot-webhook/inbound-normalizer.ts
+++ b/src/transport/bot-webhook/inbound-normalizer.ts
@@ -53,6 +53,15 @@ export type BotInboundNormalizationResult = {
   media?: BotInboundMedia;
 };
 
+type InboundMediaKind = "image" | "file" | "video";
+type MediaFailureReason = "expired_or_forbidden" | "timeout" | "size_limit" | "decrypt";
+type QuoteMediaCandidate = {
+  kind: InboundMediaKind;
+  url: string;
+  aesKey?: string;
+  explicitFilename?: string;
+};
+
 function normalizeContentType(raw?: string | null): string | undefined {
   const normalized = String(raw ?? "").trim().split(";")[0]?.trim().toLowerCase();
   return normalized || undefined;
@@ -243,6 +252,89 @@ export function looksLikeSendLocalFileIntent(rawBody: string): boolean {
   return /(发送|发给|发到|转发|把.*发|把.*发送|帮我发|给我发)/.test(t);
 }
 
+/**
+ * 根据错误信息对媒体下载/解密失败进行分类。
+ * 用于区分不同的失败原因：URL 过期、网络超时、文件超大、解密异常。
+ */
+function classifyMediaFailure(error: unknown): MediaFailureReason {
+  const message = String(error instanceof Error ? error.message : error).toLowerCase();
+  // 优先检查 URL 过期或禁止访问（403/401 或签名过期）
+  if (
+    message.includes("403") ||
+    message.includes("forbidden") ||
+    message.includes("expired") ||
+    message.includes("signature") ||
+    message.includes("status=401")
+  ) {
+    return "expired_or_forbidden";
+  }
+  // 检查网络超时（5 分钟 URL 时效窗口内的超时属于此类）
+  if (message.includes("timeout") || message.includes("timed out") || message.includes("abort")) {
+    return "timeout";
+  }
+  // 检查文件大小超限
+  if (
+    message.includes("maxbytes") ||
+    message.includes("exceed") ||
+    message.includes("too large") ||
+    message.includes("payload too large")
+  ) {
+    return "size_limit";
+  }
+  // 其他错误默认归类为解密失败
+  return "decrypt";
+}
+
+/**
+ * 从引用消息中选择并提取第一个可用的媒体候选。
+ * 
+ * 优先级规则：
+ * 1. quote.image / quote.file / quote.video：单个媒体类型直接提取
+ * 2. quote.mixed：从多个 msg_item 中提取第一个 image
+ * 3. URI 过期约 5 分钟，必须尽快下载/解密
+ * 
+ * @returns 包含 kind、url、aesKey、filename 的候选项，或 undefined
+ */
+function resolveQuoteMediaCandidate(msg: WecomInboundMessage): QuoteMediaCandidate | undefined {
+  const quote = (msg as any)?.quote;
+  const quoteType = String(quote?.msgtype ?? "").toLowerCase();
+  
+  // 处理单个媒体类型：image、file、video
+  if (quoteType === "image" || quoteType === "file" || quoteType === "video") {
+    const kind = quoteType as InboundMediaKind;
+    const url = String(quote?.[kind]?.url ?? "").trim();
+    if (!url) return undefined;
+    return {
+      kind,
+      url,
+      aesKey: quote?.[kind]?.aeskey,
+      explicitFilename: pickBotFileName(msg, quote?.[kind]),
+    };
+  }
+
+  // 处理混合消息类型：从 msg_item 数组中提取第一个图片
+  if (quoteType === "mixed" && Array.isArray(quote?.mixed?.msg_item)) {
+    for (const item of quote.mixed.msg_item) {
+      const itemType = String(item?.msgtype ?? "").toLowerCase();
+      if (itemType !== "image") {
+        continue;
+      }
+      const url = String(item?.image?.url ?? "").trim();
+      if (!url) {
+        continue;
+      }
+      return {
+        kind: "image",
+        url,
+        aesKey: item?.image?.aeskey,
+        explicitFilename: pickBotFileName(msg, item?.image),
+      };
+    }
+  }
+
+  return undefined;
+}
+
 export async function processBotInboundMessage(params: {
   target: WecomWebhookTarget;
   msg: WecomInboundMessage;
@@ -260,31 +352,75 @@ export async function processBotInboundMessage(params: {
   const maxBytes = resolveWecomMediaMaxBytes(target.config, target.account.accountId);
   const proxyUrl = resolveWecomEgressProxyUrl(target.config);
 
+  const handleMediaFailure = (payload: {
+    scope: string;
+    kind: InboundMediaKind;
+    url: string;
+    error: unknown;
+    bodyFallback: string;
+  }): BotInboundNormalizationResult => {
+    const reason = classifyMediaFailure(payload.error);
+    target.runtime.error?.(
+      `Failed to decrypt ${payload.scope} ${payload.kind}: ${String(payload.error)} reason=${reason}; 可调大 channels.wecom.mediaMaxMb（当前=${Math.round(maxBytes / (1024 * 1024))}MB）例如：openclaw config set channels.wecom.mediaMaxMb 50`,
+    );
+    recordOperationalIssue({
+      category: "media-decrypt-failed",
+      messageId: msg.msgid ? String(msg.msgid) : undefined,
+      summary: `${payload.scope} ${payload.kind} decrypt failed reason=${reason} url=${payload.url}`,
+      raw: { transport: "bot-webhook", envelopeType: "json", body: msg },
+      error: payload.error instanceof Error ? payload.error.message : String(payload.error),
+    });
+    const errorMessage =
+      typeof payload.error === "object" && payload.error
+        ? `${(payload.error as any).message}${(payload.error as any).cause ? ` (cause: ${String((payload.error as any).cause)})` : ""}`
+        : String(payload.error);
+    return { body: `${payload.bodyFallback} (decryption failed: ${errorMessage})` };
+  };
+
+  const tryDecryptMedia = async (payload: {
+    kind: InboundMediaKind;
+    url: string;
+    explicitFilename?: string;
+    aesKey?: string;
+  }): Promise<BotInboundMedia> => {
+    const decrypted = await decryptWecomMediaWithMeta(payload.url, payload.aesKey ?? aesKey, {
+      maxBytes,
+      http: { proxyUrl },
+    });
+    const inferred = inferInboundMediaMeta({
+      kind: payload.kind === "image" ? "image" : "file",
+      buffer: decrypted.buffer,
+      sourceUrl: decrypted.sourceUrl || payload.url,
+      sourceContentType: decrypted.sourceContentType,
+      sourceFilename: decrypted.sourceFilename,
+      explicitFilename: payload.explicitFilename,
+    });
+    return {
+      buffer: decrypted.buffer,
+      contentType: inferred.contentType,
+      filename: inferred.filename,
+    };
+  };
+
   if (msgtype === "image") {
     const url = String((msg as any).image?.url ?? "").trim();
     if (url && aesKey) {
       try {
-        const decrypted = await decryptWecomMediaWithMeta(url, aesKey, { maxBytes, http: { proxyUrl } });
-        const inferred = inferInboundMediaMeta({
+        const media = await tryDecryptMedia({
           kind: "image",
-          buffer: decrypted.buffer,
-          sourceUrl: decrypted.sourceUrl || url,
-          sourceContentType: decrypted.sourceContentType,
-          sourceFilename: decrypted.sourceFilename,
+          url,
           explicitFilename: pickBotFileName(msg),
+          aesKey: (msg as any).image?.aeskey,
         });
-        return { body: "[image]", media: { buffer: decrypted.buffer, contentType: inferred.contentType, filename: inferred.filename } };
+        return { body: "[image]", media };
       } catch (err) {
-        target.runtime.error?.(`图片解密失败: ${String(err)}; 可调大 channels.wecom.mediaMaxMb（当前=${Math.round(maxBytes / (1024 * 1024))}MB）例如：openclaw config set channels.wecom.mediaMaxMb 50`);
-        recordOperationalIssue({
-          category: "media-decrypt-failed",
-          messageId: msg.msgid ? String(msg.msgid) : undefined,
-          summary: `image decrypt failed url=${url}`,
-          raw: { transport: "bot-webhook", envelopeType: "json", body: msg },
-          error: err instanceof Error ? err.message : String(err),
+        return handleMediaFailure({
+          scope: "inbound",
+          kind: "image",
+          url,
+          error: err,
+          bodyFallback: "[image]",
         });
-        const errorMessage = typeof err === "object" && err ? `${(err as any).message}${(err as any).cause ? ` (cause: ${String((err as any).cause)})` : ""}` : String(err);
-        return { body: `[image] (decryption failed: ${errorMessage})` };
       }
     }
   }
@@ -293,27 +429,44 @@ export async function processBotInboundMessage(params: {
     const url = String((msg as any).file?.url ?? "").trim();
     if (url && aesKey) {
       try {
-        const decrypted = await decryptWecomMediaWithMeta(url, aesKey, { maxBytes, http: { proxyUrl } });
-        const inferred = inferInboundMediaMeta({
+        const media = await tryDecryptMedia({
           kind: "file",
-          buffer: decrypted.buffer,
-          sourceUrl: decrypted.sourceUrl || url,
-          sourceContentType: decrypted.sourceContentType,
-          sourceFilename: decrypted.sourceFilename,
+          url,
           explicitFilename: pickBotFileName(msg),
+          aesKey: (msg as any).file?.aeskey,
         });
-        return { body: "[file]", media: { buffer: decrypted.buffer, contentType: inferred.contentType, filename: inferred.filename } };
+        return { body: "[file]", media };
       } catch (err) {
-        target.runtime.error?.(`Failed to decrypt inbound file: ${String(err)}; 可调大 channels.wecom.mediaMaxMb（当前=${Math.round(maxBytes / (1024 * 1024))}MB）例如：openclaw config set channels.wecom.mediaMaxMb 50`);
-        recordOperationalIssue({
-          category: "media-decrypt-failed",
-          messageId: msg.msgid ? String(msg.msgid) : undefined,
-          summary: `file decrypt failed url=${url}`,
-          raw: { transport: "bot-webhook", envelopeType: "json", body: msg },
-          error: err instanceof Error ? err.message : String(err),
+        return handleMediaFailure({
+          scope: "inbound",
+          kind: "file",
+          url,
+          error: err,
+          bodyFallback: "[file]",
         });
-        const errorMessage = typeof err === "object" && err ? `${(err as any).message}${(err as any).cause ? ` (cause: ${String((err as any).cause)})` : ""}` : String(err);
-        return { body: `[file] (decryption failed: ${errorMessage})` };
+      }
+    }
+  }
+
+  if (msgtype === "video") {
+    const url = String((msg as any).video?.url ?? "").trim();
+    if (url && aesKey) {
+      try {
+        const media = await tryDecryptMedia({
+          kind: "video",
+          url,
+          explicitFilename: pickBotFileName(msg),
+          aesKey: (msg as any).video?.aeskey,
+        });
+        return { body: "[video]", media };
+      } catch (err) {
+        return handleMediaFailure({
+          scope: "inbound",
+          kind: "video",
+          url,
+          error: err,
+          bodyFallback: "[video]",
+        });
       }
     }
   }
@@ -330,33 +483,28 @@ export async function processBotInboundMessage(params: {
           if (content) bodyParts.push(content);
           continue;
         }
-        if ((t === "image" || t === "file") && !foundMedia && aesKey) {
-          const url = String(item[t]?.url ?? "").trim();
+        if ((t === "image" || t === "file" || t === "video") && !foundMedia && aesKey) {
+          const mediaKind = t as InboundMediaKind;
+          const url = String(item[mediaKind]?.url ?? "").trim();
           if (url) {
             try {
-              const decrypted = await decryptWecomMediaWithMeta(url, aesKey, { maxBytes, http: { proxyUrl } });
-              const inferred = inferInboundMediaMeta({
-                kind: t,
-                buffer: decrypted.buffer,
-                sourceUrl: decrypted.sourceUrl || url,
-                sourceContentType: decrypted.sourceContentType,
-                sourceFilename: decrypted.sourceFilename,
-                explicitFilename: pickBotFileName(msg, item?.[t]),
+              foundMedia = await tryDecryptMedia({
+                kind: mediaKind,
+                url,
+                explicitFilename: pickBotFileName(msg, item?.[mediaKind]),
+                aesKey: item?.[mediaKind]?.aeskey,
               });
-              foundMedia = { buffer: decrypted.buffer, contentType: inferred.contentType, filename: inferred.filename };
               bodyParts.push(`[${t}]`);
               continue;
             } catch (err) {
-              target.runtime.error?.(`Failed to decrypt mixed ${t}: ${String(err)}; 可调大 channels.wecom.mediaMaxMb（当前=${Math.round(maxBytes / (1024 * 1024))}MB）例如：openclaw config set channels.wecom.mediaMaxMb 50`);
-              recordOperationalIssue({
-                category: "media-decrypt-failed",
-                messageId: msg.msgid ? String(msg.msgid) : undefined,
-                summary: `mixed ${t} decrypt failed url=${url}`,
-                raw: { transport: "bot-webhook", envelopeType: "json", body: msg },
-                error: err instanceof Error ? err.message : String(err),
+              const failed = handleMediaFailure({
+                scope: "mixed",
+                kind: mediaKind,
+                url,
+                error: err,
+                bodyFallback: `[${t}]`,
               });
-              const errorMessage = typeof err === "object" && err ? `${(err as any).message}${(err as any).cause ? ` (cause: ${String((err as any).cause)})` : ""}` : String(err);
-              bodyParts.push(`[${t}] (decryption failed: ${errorMessage})`);
+              bodyParts.push(failed.body);
               continue;
             }
           }
@@ -364,6 +512,30 @@ export async function processBotInboundMessage(params: {
         bodyParts.push(`[${t}]`);
       }
       return { body: bodyParts.join("\n"), media: foundMedia };
+    }
+  }
+
+  if (msgtype === "text" || msgtype === "voice") {
+    const baseBody = buildInboundBody(msg);
+    // 新增支持：尝试从引用中提取候选媒体（支持 quote.image/file/video/mixed）
+    // 优先级：顶层媒体已在上面处理，如果没有顶层媒体才检查引用
+    const candidate = resolveQuoteMediaCandidate(msg);
+    if (candidate?.url && aesKey) {
+      try {
+        // 尽快下载并解密媒体（应对 5 分钟 URL 时效窗口）
+        const media = await tryDecryptMedia(candidate);
+        return { body: baseBody, media };
+      } catch (err) {
+        // 下载或解密失败则降级，保留文本但记录失败原因便于调试
+        const failed = handleMediaFailure({
+          scope: "quote",
+          kind: candidate.kind,
+          url: candidate.url,
+          error: err,
+          bodyFallback: `${baseBody}\n[quote:${candidate.kind}]`,
+        });
+        return failed;
+      }
     }
   }
 

--- a/src/transport/bot-webhook/inbound-normalizer.ts
+++ b/src/transport/bot-webhook/inbound-normalizer.ts
@@ -1,5 +1,9 @@
 import { decryptWecomMediaWithMeta } from "../../media.js";
-import { resolveWecomEgressProxyUrl, resolveWecomMediaMaxBytes } from "../../config/index.js";
+import {
+  resolveWecomEgressProxyUrl,
+  resolveWecomMediaDownloadTimeoutMs,
+  resolveWecomMediaMaxBytes,
+} from "../../config/index.js";
 import type { WecomBotInboundMessage as WecomInboundMessage } from "../../types/index.js";
 import type { WecomWebhookTarget } from "../../types/runtime-context.js";
 import { buildInboundBody } from "./message-shape.js";
@@ -351,6 +355,7 @@ export async function processBotInboundMessage(params: {
   const aesKey = target.account.encodingAESKey;
   const maxBytes = resolveWecomMediaMaxBytes(target.config, target.account.accountId);
   const proxyUrl = resolveWecomEgressProxyUrl(target.config);
+  const mediaTimeoutMs = resolveWecomMediaDownloadTimeoutMs(target.config);
 
   const handleMediaFailure = (payload: {
     scope: string;
@@ -360,8 +365,12 @@ export async function processBotInboundMessage(params: {
     bodyFallback: string;
   }): BotInboundNormalizationResult => {
     const reason = classifyMediaFailure(payload.error);
+    const hint =
+      reason === "timeout"
+        ? `可调大 channels.wecom.media.downloadTimeoutMs（当前=${mediaTimeoutMs}ms）例如：openclaw config set channels.wecom.media.downloadTimeoutMs 45000`
+        : `可调大 channels.wecom.mediaMaxMb（当前=${Math.round(maxBytes / (1024 * 1024))}MB）例如：openclaw config set channels.wecom.mediaMaxMb 50`;
     target.runtime.error?.(
-      `Failed to decrypt ${payload.scope} ${payload.kind}: ${String(payload.error)} reason=${reason}; 可调大 channels.wecom.mediaMaxMb（当前=${Math.round(maxBytes / (1024 * 1024))}MB）例如：openclaw config set channels.wecom.mediaMaxMb 50`,
+      `Failed to decrypt ${payload.scope} ${payload.kind}: ${String(payload.error)} reason=${reason}; ${hint}`,
     );
     recordOperationalIssue({
       category: "media-decrypt-failed",
@@ -383,10 +392,14 @@ export async function processBotInboundMessage(params: {
     explicitFilename?: string;
     aesKey?: string;
   }): Promise<BotInboundMedia> => {
+    const urlHost = (() => { try { return new URL(payload.url).hostname; } catch { return "?"; } })();
+    const t0 = Date.now();
+    console.log(`[wecom-media] download-start kind=${payload.kind} host=${urlHost} aesKey=${payload.aesKey ? "payload" : "account"} timeoutMs=${mediaTimeoutMs} proxy=${proxyUrl || "none"}`);
     const decrypted = await decryptWecomMediaWithMeta(payload.url, payload.aesKey ?? aesKey, {
       maxBytes,
-      http: { proxyUrl },
+      http: { proxyUrl, timeoutMs: mediaTimeoutMs },
     });
+    console.log(`[wecom-media] download-ok kind=${payload.kind} host=${urlHost} durationMs=${Date.now() - t0} bytes=${decrypted.buffer.length} contentType=${decrypted.sourceContentType ?? "?"}`);
     const inferred = inferInboundMediaMeta({
       kind: payload.kind === "image" ? "image" : "file",
       buffer: decrypted.buffer,
@@ -521,6 +534,8 @@ export async function processBotInboundMessage(params: {
     // 优先级：顶层媒体已在上面处理，如果没有顶层媒体才检查引用
     const candidate = resolveQuoteMediaCandidate(msg);
     if (candidate?.url && aesKey) {
+      const qHost = (() => { try { return new URL(candidate.url).hostname; } catch { return "?"; } })();
+      console.log(`[wecom-media] quote-candidate msgtype=${msgtype} kind=${candidate.kind} host=${qHost} aesKey=${candidate.aesKey ? "payload" : "account"} msgid=${msg.msgid ?? "?"}`);
       try {
         // 尽快下载并解密媒体（应对 5 分钟 URL 时效窗口）
         const media = await tryDecryptMedia(candidate);

--- a/src/transport/bot-webhook/message-shape.ts
+++ b/src/transport/bot-webhook/message-shape.ts
@@ -52,6 +52,8 @@ function formatQuote(quote: WecomInboundQuote): string {
   }
   if (type === "voice") return `[引用: 语音] ${quote.voice?.content || ""}`;
   if (type === "file") return `[引用: 文件] ${quote.file?.url || ""}`;
+  // 新增支持：引用视频类型 - 将在入站正规化中提取媒体并落盘
+  if (type === "video") return `[引用: 视频] ${quote.video?.url || ""}`;
   return "";
 }
 
@@ -76,6 +78,7 @@ export function buildInboundBody(msg: WecomInboundMessage): string {
     } else body = "[mixed]";
   } else if (msgtype === "image") body = `[image] ${(msg as any).image?.url || ""}`;
   else if (msgtype === "file") body = `[file] ${(msg as any).file?.url || ""}`;
+  else if (msgtype === "video") body = `[video] ${(msg as any).video?.url || ""}`;
   else if (msgtype === "event") body = `[event] ${(msg as any).event?.eventtype || ""}`;
   else if (msgtype === "stream") body = `[stream_refresh] ${(msg as any).stream?.id || ""}`;
   else body = msgtype ? `[${msgtype}]` : "";

--- a/src/transport/bot-ws/inbound.test.ts
+++ b/src/transport/bot-ws/inbound.test.ts
@@ -74,6 +74,10 @@ describe("mapBotWsFrameToInboundEvent", () => {
                 msgtype: "file",
                 file: { url: "https://example.com/doc.pdf", aeskey: "mock-file-key" },
               },
+              {
+                msgtype: "video",
+                video: { url: "https://example.com/demo.mp4", aeskey: "mock-video-key" },
+              },
             ],
           },
         },
@@ -81,7 +85,7 @@ describe("mapBotWsFrameToInboundEvent", () => {
     });
 
     expect(event.attachments).toBeDefined();
-    expect(event.attachments).toHaveLength(2);
+    expect(event.attachments).toHaveLength(3);
     expect(event.attachments![0]).toEqual({
       name: "image",
       remoteUrl: "https://example.com/image.jpg",
@@ -92,5 +96,195 @@ describe("mapBotWsFrameToInboundEvent", () => {
       remoteUrl: "https://example.com/doc.pdf",
       aesKey: "mock-file-key",
     });
+    expect(event.attachments![2]).toEqual({
+      name: "video",
+      remoteUrl: "https://example.com/demo.mp4",
+      aesKey: "mock-video-key",
+    });
+  });
+
+  it("extracts attachment from quote file in text events", () => {
+    const event = mapBotWsFrameToInboundEvent({
+      account: createBotAccount(),
+      frame: {
+        cmd: "aibot_msg_callback",
+        headers: { req_id: "req-3" },
+        body: {
+          msgid: "msg-3",
+          msgtype: "text",
+          chattype: "single",
+          from: { userid: "user-3" },
+          text: { content: "请读取这个引用文件" },
+          quote: {
+            msgtype: "file",
+            file: { url: "https://example.com/quoted.pdf", aeskey: "quoted-file-key" },
+          },
+        },
+      },
+    });
+
+    expect(event.inboundKind).toBe("text");
+    expect(event.attachments).toEqual([
+      {
+        name: "file",
+        remoteUrl: "https://example.com/quoted.pdf",
+        aesKey: "quoted-file-key",
+      },
+    ]);
+  });
+
+  it("maps top-level video to video inbound kind and attachment", () => {
+    const event = mapBotWsFrameToInboundEvent({
+      account: createBotAccount(),
+      frame: {
+        cmd: "aibot_msg_callback",
+        headers: { req_id: "req-4" },
+        body: {
+          msgid: "msg-4",
+          msgtype: "video",
+          chattype: "single",
+          from: { userid: "user-4" },
+          video: { url: "https://example.com/top-video.mp4", aeskey: "top-video-key" },
+        },
+      },
+    });
+
+    expect(event.inboundKind).toBe("video");
+    expect(event.attachments).toEqual([
+      {
+        name: "video",
+        remoteUrl: "https://example.com/top-video.mp4",
+        aesKey: "top-video-key",
+      },
+    ]);
+  });
+
+  it("extracts attachment from quote image in text events", () => {
+    const event = mapBotWsFrameToInboundEvent({
+      account: createBotAccount(),
+      frame: {
+        cmd: "aibot_msg_callback",
+        headers: { req_id: "req-5" },
+        body: {
+          msgid: "msg-5",
+          msgtype: "text",
+          chattype: "single",
+          from: { userid: "user-5" },
+          text: { content: "请看这张引用图片" },
+          quote: {
+            msgtype: "image",
+            image: { url: "https://example.com/quoted.jpg", aeskey: "quoted-image-key" },
+          },
+        },
+      },
+    });
+
+    expect(event.inboundKind).toBe("text");
+    expect(event.attachments).toEqual([
+      {
+        name: "image",
+        remoteUrl: "https://example.com/quoted.jpg",
+        aesKey: "quoted-image-key",
+      },
+    ]);
+  });
+
+  it("extracts attachment from quote video in text events", () => {
+    const event = mapBotWsFrameToInboundEvent({
+      account: createBotAccount(),
+      frame: {
+        cmd: "aibot_msg_callback",
+        headers: { req_id: "req-6" },
+        body: {
+          msgid: "msg-6",
+          msgtype: "voice",
+          chattype: "single",
+          from: { userid: "user-6" },
+          voice: { content: "语音转写内容" },
+          quote: {
+            msgtype: "video",
+            video: { url: "https://example.com/quoted.mp4", aeskey: "quoted-video-key" },
+          },
+        },
+      },
+    });
+
+    expect(event.inboundKind).toBe("voice");
+    expect(event.attachments).toEqual([
+      {
+        name: "video",
+        remoteUrl: "https://example.com/quoted.mp4",
+        aesKey: "quoted-video-key",
+      },
+    ]);
+  });
+
+  it("prioritizes top-level media over quote media in WS events", () => {
+    const event = mapBotWsFrameToInboundEvent({
+      account: createBotAccount(),
+      frame: {
+        cmd: "aibot_msg_callback",
+        headers: { req_id: "req-7" },
+        body: {
+          msgid: "msg-7",
+          msgtype: "image",
+          chattype: "group",
+          chatid: "group-7",
+          from: { userid: "user-7" },
+          image: { url: "https://example.com/top.jpg", aeskey: "top-image-key" },
+          quote: {
+            msgtype: "file",
+            file: { url: "https://example.com/quoted.pdf", aeskey: "quoted-file-key" },
+          },
+        },
+      },
+    });
+
+    // Should only include top-level image, not quote file
+    expect(event.inboundKind).toBe("image");
+    expect(event.attachments).toEqual([
+      {
+        name: "image",
+        remoteUrl: "https://example.com/top.jpg",
+        aesKey: "top-image-key",
+      },
+    ]);
+  });
+
+  it("extracts first image from quote.mixed in text events", () => {
+    const event = mapBotWsFrameToInboundEvent({
+      account: createBotAccount(),
+      frame: {
+        cmd: "aibot_msg_callback",
+        headers: { req_id: "req-8" },
+        body: {
+          msgid: "msg-8",
+          msgtype: "text",
+          chattype: "single",
+          from: { userid: "user-8" },
+          text: { content: "这个引用有图文内容" },
+          quote: {
+            msgtype: "mixed",
+            mixed: {
+              msg_item: [
+                { msgtype: "text", text: { content: "一些文本" } },
+                { msgtype: "image", image: { url: "https://example.com/mixed-img1.jpg", aeskey: "mixed-key-1" } },
+                { msgtype: "image", image: { url: "https://example.com/mixed-img2.jpg", aeskey: "mixed-key-2" } },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(event.inboundKind).toBe("text");
+    // Should only extract first image from quote.mixed
+    expect(event.attachments).toEqual([
+      {
+        name: "image",
+        remoteUrl: "https://example.com/mixed-img1.jpg",
+        aesKey: "mixed-key-1",
+      },
+    ]);
   });
 });

--- a/src/transport/bot-ws/inbound.ts
+++ b/src/transport/bot-ws/inbound.ts
@@ -22,11 +22,25 @@ function resolveInboundKind(message: BaseMessage | EventMessage): WecomInboundKi
       return "file";
     case "voice":
       return "voice";
+    case "video":
+      return "video";
     case "mixed":
       return "mixed";
     default:
       return "text";
   }
+}
+
+function pushAttachment(
+  list: NonNullable<UnifiedInboundEvent["attachments"]>,
+  name: "image" | "file" | "video",
+  remoteUrl?: string,
+  aesKey?: string,
+): void {
+  if (!remoteUrl) {
+    return;
+  }
+  list.push({ name, remoteUrl, aesKey });
 }
 
 function resolveEventText(message: BaseMessage | EventMessage, account: ResolvedBotAccount): string {
@@ -56,25 +70,58 @@ export function mapBotWsFrameToInboundEvent(params: {
   const inboundKind = resolveInboundKind(body);
 
   let attachments: UnifiedInboundEvent["attachments"];
+  const collected: NonNullable<UnifiedInboundEvent["attachments"]> = [];
   if (body.msgtype === "image") {
-    attachments = [{ name: "image", remoteUrl: (body as any).image?.url, aesKey: (body as any).image?.aeskey }];
+    pushAttachment(collected, "image", (body as any).image?.url, (body as any).image?.aeskey);
   } else if (body.msgtype === "file") {
-    attachments = [{ name: "file", remoteUrl: (body as any).file?.url, aesKey: (body as any).file?.aeskey }];
+    pushAttachment(collected, "file", (body as any).file?.url, (body as any).file?.aeskey);
+  } else if (body.msgtype === "video") {
+    pushAttachment(collected, "video", (body as any).video?.url, (body as any).video?.aeskey);
   } else if (body.msgtype === "mixed") {
     const items = (body as any).mixed?.msg_item;
     if (Array.isArray(items)) {
-      attachments = [];
       for (const item of items) {
-        if (item.msgtype === "image" && item.image?.url) {
-          attachments.push({ name: "image", remoteUrl: item.image.url, aesKey: item.image.aeskey });
-        } else if (item.msgtype === "file" && item.file?.url) {
-          attachments.push({ name: "file", remoteUrl: item.file.url, aesKey: item.file.aeskey });
+        const itemType = String(item.msgtype ?? "").toLowerCase();
+        if (itemType === "image") {
+          pushAttachment(collected, "image", item.image?.url, item.image?.aeskey);
+        } else if (itemType === "file") {
+          pushAttachment(collected, "file", item.file?.url, item.file?.aeskey);
+        } else if (itemType === "video") {
+          pushAttachment(collected, "video", item.video?.url, item.video?.aeskey);
         }
       }
-      if (attachments.length === 0) {
-        attachments = undefined;
+    }
+  }
+
+  // 新增支持：如果没有顶层媒体，尝试从引用中提取媒体附件
+  // 优先级：quote.image/file/video 优先，其次 quote.mixed 中第一个图片
+  if (collected.length === 0) {
+    const quote = (body as any).quote;
+    if (quote) {
+      const quoteType = String(quote.msgtype ?? "").toLowerCase();
+      // 处理单个媒体类型的引用
+      if (quoteType === "image") {
+        pushAttachment(collected, "image", quote.image?.url, quote.image?.aeskey);
+      } else if (quoteType === "file") {
+        pushAttachment(collected, "file", quote.file?.url, quote.file?.aeskey);
+      } else if (quoteType === "video") {
+        pushAttachment(collected, "video", quote.video?.url, quote.video?.aeskey);
+      } 
+      // 处理图文混合类型：只提取第一个图片以保持与 webhook 一致
+      else if (quoteType === "mixed" && Array.isArray(quote.mixed?.msg_item)) {
+        for (const item of quote.mixed.msg_item) {
+          const itemType = String(item.msgtype ?? "").toLowerCase();
+          if (itemType === "image") {
+            pushAttachment(collected, "image", item.image?.url, item.image?.aeskey);
+            break;
+          }
+        }
       }
     }
+  }
+
+  if (collected.length > 0) {
+    attachments = collected;
   }
 
   return {
@@ -111,6 +158,6 @@ export function mapBotWsFrameToInboundEvent(params: {
         envelopeType: "ws",
       },
     },
-    attachments,
+    ...(attachments && { attachments }),
   };
 }

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -59,14 +59,16 @@ export type WecomBotInboundEvent = WecomBotInboundBase & {
  * **WecomInboundQuote (引用消息)**
  * 
  * 消息中引用的原始内容（如回复某条消息）。
- * 支持引用文本、图片、混合类型、语音、文件等。
+ * 支持引用文本、图片、混合类型、语音、文件、视频等多种媒体类型。
+ * 
+ * 注意：引用中的媒体 URL 时效约 5 分钟，必须尽快下载和解密。
  */
 export type WecomInboundQuote = {
-    msgtype?: "text" | "image" | "mixed" | "voice" | "file";
+    msgtype?: "text" | "image" | "mixed" | "voice" | "file" | "video";
     /** 引用文本内容 */
     text?: { content?: string };
-    /** 引用图片 URL */
-    image?: { url?: string };
+    /** 引用图片 URL，可包含出现时的加密密钥 aeskey */
+    image?: { url?: string; aeskey?: string };
     /** 引用混合消息 (图文) */
     mixed?: {
         msg_item?: Array<{
@@ -75,10 +77,12 @@ export type WecomInboundQuote = {
             image?: { url?: string };
         }>;
     };
-    /** 引用语音 */
+    /** 引用语音 - 仅含转写文本，无 URL 需下载（按纯文本处理） */
     voice?: { content?: string };
-    /** 引用文件 */
-    file?: { url?: string };
+    /** 引用文件 URL 及其加密密钥 */
+    file?: { url?: string; aeskey?: string };
+    /** 引用视频 URL 及其加密密钥（新增支持） */
+    video?: { url?: string; aeskey?: string };
 };
 
 export type WecomBotInboundMessage =


### PR DESCRIPTION
测试WS和webhook的bot渠道机器人均可以在群聊或者私聊中正确的在引用中获取到文件了
webhook机器人可能要配置一下超时时间

openclaw config set channels.wecom.media.downloadTimeoutMs 45000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for video attachments in WeCom messages.
  * Enabled media decryption from quoted messages.
  * Added configurable media download timeout with environment variable support.

* **Bug Fixes**
  * Improved error handling to distinguish timeout errors from other network failures.

* **Chores**
  * Enhanced error diagnostics and logging for media download failures.
  * Extended type definitions to support video in message quotes with encryption key data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->