### PR TITLE
For image type, send caption text first, then the image

### DIFF
--- a/src/transport/agent-api/delivery.ts
+++ b/src/transport/agent-api/delivery.ts
@@ -30,6 +30,16 @@ export async function deliverAgentApiMedia(params: {
     buffer: params.buffer,
     filename: params.filename,
   });
+
+  // For image type, send caption text first, then the image
+  if (mediaType === "image" && params.text?.trim()) {
+    await sendAgentApiTextReply({
+      agent: params.agent,
+      target: params.target,
+      text: params.text,
+    });
+  }
+
   await sendAgentApiMediaReply({
     agent: params.agent,
     target: params.target,


### PR DESCRIPTION
修复“发送图文时，文本没有正确发送“的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image messages now support accompanying text captions. When sharing images with text, messages will send text content separately before the media, providing a more intuitive messaging experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->