### PR TITLE
fix: ensure dist/ files are included in npm package 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,37 @@
+# NOTE: Presence of this file makes npm IGNORE .gitignore for packing.
+# Combined with the package.json "files" whitelist, this guarantees that
+# the compiled dist/ output is always shipped to the registry, regardless
+# of how .gitignore is configured.
+
+# Source / tooling -- not needed at runtime (dist/ is the runtime entry).
+src/
+scripts/
+*.test.ts
+*.test.js
+*.tsbuildinfo
+tsconfig.json
+vitest.config.ts
+index.test.ts
+
+# Dev artifacts
+node_modules/
+coverage/
+.nyc_output/
+*.log
+
+# Repo metadata that doesn't belong in the npm package
+.github/
+.claude/
+.git/
+.gitignore
+.DS_Store
+.vscode/
+.idea/
+
+# Internal planning docs (keep README/LICENSE/changelog only)
+UPSTREAM_CONFIG.md
+UPSTREAM_PLAN.md
+GOVERNANCE.md
+SKILLS_CAL.md
+SKILLS_DOC.md
+compat-single-account.md

--- a/changelog/v2.4.161.md
+++ b/changelog/v2.4.161.md
@@ -1,0 +1,17 @@
+# OpenClaw WeCom 插件 v2.4.161 变更简报
+
+> [!IMPORTANT]
+> `v2.4.161` 修复了 `2.4.160` 发布到 npm 时因缺少 `dist/` 编译产物，导致 `openclaw update` 时 OpenClaw 校验器拒绝安装并把 wecom 插件自动 `disabled` 的问题。
+
+## 2026-05-11（v2.4.161）
+
+### 修复
+- 【关键修复】发布到 npm 的 tarball 现在保证包含 `dist/index.js` 等编译产物。
+  - 现象：openclaw升级到 `v2026.5.7` 后 `openclaw update` 报错 `package install requires compiled runtime output for TypeScript entry ./index.ts: expected ./dist/index.js, ./dist/index.mjs, ./dist/index.cjs, ./index.js, ./index.mjs, ./index.cjs`，OpenClaw 把插件自动设为 `disabled`。
+  - 根因：仓库 `.gitignore` 把 `dist/` 列为忽略，而历史发布在某些情形下未尊重 `package.json#files` 白名单，导致 `dist/` 没被打进 tarball。
+  - 修复：
+    1. 新增 `.npmignore`，覆盖 `.gitignore` 的打包行为，明确把 `dist/` 保留在 tarball 中。
+    2. `package.json` 的 `prepack` 钩子现在执行 `npm run build && npm run verify-dist`，新的 `verify-dist` 守护脚本在 `dist/index.js` 缺失时立即让发布失败。
+- 【清单元信息】`openclaw.plugin.json` 新增 `channelConfigs.wecom`（含 `label`、`description`、`schema`、`commands`），消除 `openclaw doctor` 的告警：
+  - `channel plugin manifest declares wecom without channelConfigs metadata; add openclaw.plugin.json#channelConfigs so config schema and setup surfaces work before runtime loads`。
+

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,21 @@
 {
   "id": "wecom",
   "channels": ["wecom"],
+  "channelConfigs": {
+    "wecom": {
+      "label": "WeCom (企业微信)",
+      "description": "企业微信官方推荐三方插件，默认 Bot WebSocket 配置简单，支持加密媒体解密、Agent 主动发消息与多账号接入。",
+      "schema": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {}
+      },
+      "commands": {
+        "nativeCommandsAutoEnabled": false,
+        "nativeSkillsAutoEnabled": false
+      }
+    }
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,20 @@
 {
   "name": "@yanhaidao/wecom",
-  "version": "2.4.160",
+  "version": "2.4.161",
   "description": "OpenClaw 企业微信（WeCom）插件，默认 Bot WebSocket，支持加密媒体解密、Agent 主动发消息与多账号接入",
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "index.ts",
+    "openclaw.plugin.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "verify-dist": "node -e \"const fs=require('fs');const f='./dist/index.js';if(!fs.existsSync(f)){console.error('Missing compiled runtime output:',f);process.exit(1)}\"",
+    "prepack": "npm run build && npm run verify-dist"
+  },
   "license": "ISC",
   "author": "YanHaidao (VX: YanHaidao)",
   "repository": {
@@ -28,6 +41,9 @@
   "openclaw": {
     "extensions": [
       "./index.ts"
+    ],
+    "runtimeExtensions": [
+      "./dist/index.js"
     ],
     "channel": {
       "id": "wecom",


### PR DESCRIPTION
fix: ensure dist/ files are included in npm package and add channelConfigs to plugin manifest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v2.4.161

* **Bug Fixes**
  * Resolved npm publishing issue that prevented compiled artifacts from being included in v2.4.160, causing plugin validation failures and automatic disabling.

* **New Features**
  * Added WeCom channel configuration support.

* **Chores**
  * Version bumped to v2.4.161.
  * Enhanced package publication process to verify all required artifacts are included.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YanHaidao/wecom/pull/67)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->