### PR TITLE
chore: update openclaw peer/dev dependency to ^2026.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "undici": "^7.20.0"
   },
   "devDependencies": {
-    "@types/node": "^25.2.0",
-    "openclaw": "^2026.3.23-2",
+    "@types/node": "^22.22.0",
+    "openclaw": "^2026.7.0",
     "typescript": "^5.9.3",
     "vitest": "^2.1.8"
   },
   "peerDependencies": {
-    "openclaw": "^2026.3.23-2"
+    "openclaw": "^2026.7.0"
   },
   "openclaw": {
     "extensions": [
@@ -68,5 +68,10 @@
       "localPath": "extensions/wecom",
       "defaultChoice": "npm"
     }
-  }
+  },
+  "keywords": [],
+  "bugs": {
+    "url": "https://github.com/YanHaidao/wecom/issues"
+  },
+  "homepage": "https://github.com/YanHaidao/wecom#readme"
 }

--- a/package.json
+++ b/package.json
@@ -68,10 +68,5 @@
       "localPath": "extensions/wecom",
       "defaultChoice": "npm"
     }
-  },
-  "keywords": [],
-  "bugs": {
-    "url": "https://github.com/YanHaidao/wecom/issues"
-  },
-  "homepage": "https://github.com/YanHaidao/wecom#readme"
+  }
 }


### PR DESCRIPTION
## Summary

Update OpenClaw peer/dev dependencies from `^2026.3.23-2` to `^2026.7.0` to support OpenClaw 2026.7.x.

## Changes

- **package.json**: Bump `openclaw` devDependency and peerDependency to `^2026.7.0`
- **package.json**: Update `@types/node` from `^25.2.0` to `^22.22.0` to match Node.js v22 runtime

## Verification

Verified all plugin-sdk imports used by this plugin are compatible between openclaw ^2026.3.23-2 and ^2026.7.0. Type signatures for all used symbols are unchanged. Plugin compiles cleanly with no errors against the new dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated compatibility with the latest supported OpenClaw release.
  * Adjusted Node.js type definitions for improved development environment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->